### PR TITLE
Remove `version` key from `setup_remote_docker` CircleCI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,7 @@ jobs:
     <<: *docker-defaults
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
+      - setup_remote_docker
       - *test
       - run:
           name: Webpack
@@ -66,8 +65,7 @@ jobs:
     <<: *docker-defaults
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
+      - setup_remote_docker
       - *test
       - run:
           name: Webpack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,6 @@ aws-export: &aws-export
     command: |
       echo 'export AWS_ACCESS_KEY_ID=${WEB_CDN_AWS_ACCESS_KEY_ID}' >> $BASH_ENV
       echo 'export AWS_SECRET_ACCESS_KEY=${WEB_CDN_AWS_SECRET_ACCESS_KEY}' >> $BASH_ENV
-      echo 'export AWS_REGION=us-east-1' >> $BASH_ENV
-      # This appears to necessary for this project only, to prevent error:
-      #     "Invalid endpoint: https://s3..amazonaws.com"
-      echo 'export AWS_DEFAULT_REGION=${AWS_REGION}' >> $BASH_ENV
       echo 'export S3_URI=${S3_URI}' >> $BASH_ENV
 
 copy_files: &copy_files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ aws-export: &aws-export
       echo 'export AWS_ACCESS_KEY_ID=${WEB_CDN_AWS_ACCESS_KEY_ID}' >> $BASH_ENV
       echo 'export AWS_SECRET_ACCESS_KEY=${WEB_CDN_AWS_SECRET_ACCESS_KEY}' >> $BASH_ENV
       echo 'export AWS_REGION=us-east-1' >> $BASH_ENV
+      # This appears to necessary for this project only, to prevent error:
+      #     "Invalid endpoint: https://s3..amazonaws.com"
+      echo 'export AWS_DEFAULT_REGION=${AWS_REGION}' >> $BASH_ENV
       echo 'export S3_URI=${S3_URI}' >> $BASH_ENV
 
 copy_files: &copy_files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ aws-export: &aws-export
     command: |
       echo 'export AWS_ACCESS_KEY_ID=${WEB_CDN_AWS_ACCESS_KEY_ID}' >> $BASH_ENV
       echo 'export AWS_SECRET_ACCESS_KEY=${WEB_CDN_AWS_SECRET_ACCESS_KEY}' >> $BASH_ENV
+      echo 'export AWS_REGION=us-east-1' >> $BASH_ENV
       echo 'export S3_URI=${S3_URI}' >> $BASH_ENV
 
 copy_files: &copy_files


### PR DESCRIPTION
Remote Docker was locked to 19.03.13.  Our newer projects using `setup_remote_docker` step without `version` key are using version 24.