### PR TITLE
.circleci/config.yml: explicity set `setup_remote_docker` `version` attribute to "default"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
     <<: *docker-defaults
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: default
       - *test
       - run:
           name: Webpack
@@ -61,7 +62,8 @@ jobs:
     <<: *docker-defaults
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: default
       - *test
       - run:
           name: Webpack


### PR DESCRIPTION
monday.com: [Remote Docker image deprecation](https://nyu-lib.monday.com/boards/785684675/pulses/6140895635)
