### PR TITLE
Remove incorrect options object from create element call

### DIFF
--- a/js/test/test.setup.js
+++ b/js/test/test.setup.js
@@ -6,7 +6,7 @@ function redefineScript({ institution, id }) {
   script.setAttribute('src', `http://cdn.example.com/app.min.js?institution=${institution}&element_id=${id}`);
   Object.defineProperty(document, 'currentScript', { value: script });
 
-  const injectionElement = document.createElement('div', { id });
+  const injectionElement = document.createElement('div');
   injectionElement.setAttribute('id', id);
   document.body.appendChild(injectionElement);
 }

--- a/js/utils/searchRedirects.js
+++ b/js/utils/searchRedirects.js
@@ -47,7 +47,7 @@ export const primoSearch = ({ tab, scope, bobcatUrl, search, institution, vid, s
   let qsParams;
 
   // Redirect to BobCat search if `search` is non-empty.
-  // If `search` is empty of meaningful user input, redirect to the  BobCat home
+  // If `search` is empty of meaningful user input, redirect to the BobCat home
   // page instead of redirecting to a BobCat blank search, which returns error messages
   // that are potentially confusing.
   //


### PR DESCRIPTION
_js/test/test.setup.js_ - `redefineScript()`: remove `{ id }` arg from `document.createElement()` call.  The 2nd arg to `document.createElement()` is an options object with property `is`.  `{ id }` might have been a mistaken attempt set the `id` attribute for the created <div>.
