### PR TITLE
Upgrade node to v20 and add workaround to prevent "error:0308010C:digital envelope routines::unsupported"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:16-alpine
+FROM node:20-alpine
 
 ENV INSTALL_PATH /app
 ENV PATH $INSTALL_PATH/node_modules/.bin:$PATH
+# Prevent error: "error:0308010C:digital envelope routines::unsupported"
+# See https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
+# TODO: Remove this workaround after replacing webpack.
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 ADD package.json yarn.lock /tmp/
 RUN cd /tmp && yarn install

--- a/js/test/Dockerfile
+++ b/js/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/nyulibraries/chromium_headless_node:16-chromium_latest
+FROM quay.io/nyulibraries/chromium_headless_node:20-chromium_latest
 
 ENV INSTALL_PATH /app
 ENV PATH $INSTALL_PATH/node_modules/.bin:$PATH

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:chrome-debugger": "karma start --browsers=Chrome --single-run=false --debug"
   },
   "engines": {
-    "node": "16"
+    "node": "20"
   },
   "resolutions": {
     "kind-of": "^6.0.3",


### PR DESCRIPTION
Upgrade Node to v20 (minimum v18 needed for `vitest`), and add workaround to Dockerfile to prevent [Error message "error:0308010C:digital envelope routines::unsupported"](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported) when running `webpack` Docker Compose service.