### PR TITLE
shallowRender.spec.js: fix test for first tabe -- change bobcat_embed_tabs_inner -> bobcat_embed_tabs_inside

### DIFF
--- a/js/test/App.vue/shallowRender.spec.js
+++ b/js/test/App.vue/shallowRender.spec.js
@@ -63,8 +63,8 @@ describe('shallow render', () => {
           expect(firstTab.classes('bobcat_embed_tabs_first')).toBe(true);
         });
 
-        it('does not have inner, last classes', () => {
-          expect(firstTab.classes('bobcat_embed_tabs_inner')).toBe(false);
+        it('does not have inside, last classes', () => {
+          expect(firstTab.classes('bobcat_embed_tabs_inside')).toBe(false);
           expect(firstTab.classes('bobcat_embed_tabs_last')).toBe(false);
         });
 


### PR DESCRIPTION
Fix class name: "bobcat_embed_tabs_inner" -> "bobcat_embed_tabs_inside"
Bug went undetected because test is for nonexistence of this and another class where they wouldn't be appropriate.  Due to the wrong selector, non-existence was guaranteed even when existence is appropriate.