### PR TITLE
Include scope in primoSearch query string when search is empty

### DIFF
--- a/src/utils/searchRedirects.js
+++ b/src/utils/searchRedirects.js
@@ -95,7 +95,24 @@ export const primoSearch = ( { tab, scope, bobcatUrl, search, institution, vid, 
             { sort: qsSortBy( qsOrder ), encode: false },
         );
     } else {
-        qsParams = `vid=${ vid }`;
+        // Include scope in the query string even when search is empty
+        qsParams = queryStringify(
+            {
+                institution,
+                vid,
+                tab,
+                search_scope: scope,
+            },
+            {
+                sort: qsSortBy( [ 
+                    'institution',
+                    'vid',
+                    'tab',
+                    'search_scope', 
+                ] ),
+                encode: false, 
+            },
+        );
     }
 
     return `${ bobcatUrl }/discovery/${ searchMethod }?${ qsParams }`;


### PR DESCRIPTION
Re: https://nyu-lib.monday.com/boards/765008773/pulses/6368890152