### PR TITLE
Reuse existing shared tab configs

### DIFF
--- a/config/institutions/nyu.js
+++ b/config/institutions/nyu.js
@@ -19,9 +19,8 @@ export default [
         label: 'Databases',
     },
     {
-        label: 'Research Guides',
-        title: 'Guides to help you find library resources on specific subjects and courses',
-        open : {
+        ...shared.tabs.subjectGuides,
+        open: {
             href  : 'https://guides.nyu.edu',
             target: '_blank',
         },

--- a/config/institutions/nyu.js
+++ b/config/institutions/nyu.js
@@ -15,12 +15,8 @@ export default [
         ],
     },
     {
+        ...shared.tabs.guidesArticles,
         label: 'Databases',
-        title: 'Search databases for articles or browse databases by subject',
-        open : {
-            href  : 'http://guides.nyu.edu/arch',
-            target: '_blank',
-        },
     },
     {
         label: 'Research Guides',


### PR DESCRIPTION
DRY up Databases and Research Guides configurations by using pre-existing shared configs and overriding only what's changed.