### PR TITLE
Simplify Primo empty search redirect to home page and add tests; replace "bobcatUrl` w/ "primoUrl"; upgrade NYU_HOME browser override files

### DIFF
--- a/browser-overrides/globalhome.nyu.edu/js/chunk-557bd6d4.17146a8e.js
+++ b/browser-overrides/globalhome.nyu.edu/js/chunk-557bd6d4.17146a8e.js
@@ -77,7 +77,7 @@
         a.r(e);
         var s = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 staticClass: "home"
             }, [t.showSearch ? t._e() : e("button", {
@@ -98,23 +98,23 @@
                     gutter: 30
                 }
             }, [t._l(t.serviceCards, (function(a) {
-                return [t.isValidCardType(a) ? e("basic-card", {
-                    key: a.id,
-                    attrs: {
-                        content: a
-                    }
-                }) : t._e(), "promo" != a.cardType || t.dismissed(a) ? t._e() : e("tutorial-card", {
-                    key: a.id,
-                    attrs: {
-                        content: a
-                    }
-                }), "librariestype" == a.cardType ? e("library-card", {
-                    key: a.id,
-                    attrs: {
-                        content: a
-                    }
-                }) : t._e()]
-            }
+                    return [t.isValidCardType(a) ? e("basic-card", {
+                        key: a.id,
+                        attrs: {
+                            content: a
+                        }
+                    }) : t._e(), "promo" != a.cardType || t.dismissed(a) ? t._e() : e("tutorial-card", {
+                        key: a.id,
+                        attrs: {
+                            content: a
+                        }
+                    }), "librariestype" == a.cardType ? e("library-card", {
+                        key: a.id,
+                        attrs: {
+                            content: a
+                        }
+                    }) : t._e()]
+                }
             ))], 2)], 1), t.showSearch ? e("div", [e("search-results")], 1) : t._e(), t.customize ? [e("draggable-customize", {
                 attrs: {
                     cards: t.serviceCards
@@ -129,10 +129,10 @@
                 }
             })] : t._e()], 2)
         }
-          , i = []
-          , n = function() {
+            , i = []
+            , n = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("article", {
                 ref: "container",
                 staticClass: "card-contain",
@@ -160,64 +160,64 @@
                     shrink: t.shrinkClass
                 }
             }, [t._t("default", (function() {
-                return [t.cardProps.frontContent ? e("vue-markdown", {
-                    staticClass: "markdown padding15",
-                    attrs: {
-                        source: t.content.frontContent,
-                        anchorAttributes: {
-                            target: "_blank"
-                        }
-                    }
-                }) : t._e(), t._l(t.cardProps.collapsableSections, (function(a) {
-                    return [e("collapse-section", {
-                        key: a.id,
-                        staticClass: "margin-fix",
+                    return [t.cardProps.frontContent ? e("vue-markdown", {
+                        staticClass: "markdown padding15",
                         attrs: {
-                            titleText: a.title,
-                            expanded: !a.userSectionState.collapsed
-                        },
-                        on: {
-                            toggled: function(e) {
-                                return t.shrinkSection(e, a)
-                            }
-                        }
-                    }, [e("vue-markdown", {
-                        staticClass: "markdown",
-                        attrs: {
-                            source: a.collapsableSection,
+                            source: t.content.frontContent,
                             anchorAttributes: {
                                 target: "_blank"
                             }
                         }
-                    })], 1)]
-                }
-                )), t.feed && t.content && null != t.content.feedType && 0 == t.feed.needsGoogleAuth ? e("collapse-section", {
-                    ref: "activityFeed",
-                    staticClass: "activity-feed",
-                    attrs: {
-                        cardId: t.cardProps.id,
-                        titleText: "Activity Feed",
-                        feedType: t.feed.feedName,
-                        refresh: !0,
-                        expanded: !t.content.userSettings.feedCollapsed
-                    },
-                    on: {
-                        toggled: function(e) {
-                            return t.openFeed(e)
+                    }) : t._e(), t._l(t.cardProps.collapsableSections, (function(a) {
+                            return [e("collapse-section", {
+                                key: a.id,
+                                staticClass: "margin-fix",
+                                attrs: {
+                                    titleText: a.title,
+                                    expanded: !a.userSectionState.collapsed
+                                },
+                                on: {
+                                    toggled: function(e) {
+                                        return t.shrinkSection(e, a)
+                                    }
+                                }
+                            }, [e("vue-markdown", {
+                                staticClass: "markdown",
+                                attrs: {
+                                    source: a.collapsableSection,
+                                    anchorAttributes: {
+                                        target: "_blank"
+                                    }
+                                }
+                            })], 1)]
                         }
-                    }
-                }, ["GOOGLE_CALENDAR" == t.feed.feedName ? e("calendar-feed", {
-                    attrs: {
-                        maxItems: t.maxItems,
-                        feedType: t.feed.feedName
-                    }
-                }) : t._e(), e("general-feed", {
-                    attrs: {
-                        maxItems: t.maxItems,
-                        feedType: t.feed.feedName
-                    }
-                })], 1) : t._e()]
-            }
+                    )), t.feed && t.content && null != t.content.feedType && 0 == t.feed.needsGoogleAuth ? e("collapse-section", {
+                        ref: "activityFeed",
+                        staticClass: "activity-feed",
+                        attrs: {
+                            cardId: t.cardProps.id,
+                            titleText: "Activity Feed",
+                            feedType: t.feed.feedName,
+                            refresh: !0,
+                            expanded: !t.content.userSettings.feedCollapsed
+                        },
+                        on: {
+                            toggled: function(e) {
+                                return t.openFeed(e)
+                            }
+                        }
+                    }, ["GOOGLE_CALENDAR" == t.feed.feedName ? e("calendar-feed", {
+                        attrs: {
+                            maxItems: t.maxItems,
+                            feedType: t.feed.feedName
+                        }
+                    }) : t._e(), e("general-feed", {
+                        attrs: {
+                            maxItems: t.maxItems,
+                            feedType: t.feed.feedName
+                        }
+                    })], 1) : t._e()]
+                }
             ))], 2), t.content && t.displayNotification ? e("card-notification", {
                 attrs: {
                     notification: t.content.notification
@@ -286,11 +286,11 @@
                 on: {
                     click: function(e) {
                         return e.preventDefault(),
-                        t.flipCard()
+                            t.flipCard()
                     },
                     keydown: function(e) {
                         return !e.type.indexOf("key") && t._k(e.keyCode, "enter", 13, e.key, "Enter") ? null : (e.preventDefault(),
-                        t.flipCard())
+                            t.flipCard())
                     }
                 }
             })], 1), e("collapse-button", {
@@ -301,11 +301,11 @@
                 on: {
                     click: function(e) {
                         return e.preventDefault(),
-                        t.shrinkCard()
+                            t.shrinkCard()
                     },
                     keydown: function(e) {
                         return !e.type.indexOf("key") && t._k(e.keyCode, "enter", 13, e.key, "Enter") ? null : (e.preventDefault(),
-                        t.shrinkCard())
+                            t.shrinkCard())
                     }
                 }
             }), e("favorite-button", {
@@ -316,11 +316,11 @@
                 on: {
                     click: function(e) {
                         return e.preventDefault(),
-                        t.favoriteCard()
+                            t.favoriteCard()
                     },
                     keydown: function(e) {
                         return !e.type.indexOf("key") && t._k(e.keyCode, "enter", 13, e.key, "Enter") ? null : (e.preventDefault(),
-                        t.favoriteCard())
+                            t.favoriteCard())
                     }
                 }
             })], 1), t.flipped ? e("div", {
@@ -403,68 +403,68 @@
                     },
                     keydown: function(e) {
                         return !e.type.indexOf("key") && t._k(e.keyCode, "enter", 13, e.key, "Enter") ? null : (e.preventDefault(),
-                        t.flipCard())
+                            t.flipCard())
                     }
                 }
             })], 1) : t._e()])])
         }
-          , r = []
-          , o = (a("a481"),
-        a("444c"))
-          , c = a("ce5e")
-          , l = (a("7f7f"),
-        function() {
-            var t = this
-              , e = t._self._c;
-            return e("div", {
-                staticClass: "slidecontainer"
-            }, [e("div", {
-                staticClass: "slide-range"
-            }, [e("input", {
-                directives: [{
-                    name: "model",
-                    rawName: "v-model",
-                    value: t.rangeVal,
-                    expression: "rangeVal"
-                }],
-                staticClass: "slider",
-                attrs: {
-                    type: "range",
-                    "aria-live": "assertive",
-                    "aria-label": t.name + " slider between " + t.minimum + " & " + t.maximum + " changed to " + t.rangeVal,
-                    min: t.minimum,
-                    max: t.maximum
-                },
-                domProps: {
-                    value: t.rangeVal
-                },
-                on: {
-                    change: function(e) {
-                        return t.slideEmit()
-                    },
-                    __r: function(e) {
-                        t.rangeVal = e.target.value
-                    }
+            , r = []
+            , o = (a("a481"),
+            a("444c"))
+            , c = a("ce5e")
+            , l = (a("7f7f"),
+                function() {
+                    var t = this
+                        , e = t._self._c;
+                    return e("div", {
+                        staticClass: "slidecontainer"
+                    }, [e("div", {
+                        staticClass: "slide-range"
+                    }, [e("input", {
+                        directives: [{
+                            name: "model",
+                            rawName: "v-model",
+                            value: t.rangeVal,
+                            expression: "rangeVal"
+                        }],
+                        staticClass: "slider",
+                        attrs: {
+                            type: "range",
+                            "aria-live": "assertive",
+                            "aria-label": t.name + " slider between " + t.minimum + " & " + t.maximum + " changed to " + t.rangeVal,
+                            min: t.minimum,
+                            max: t.maximum
+                        },
+                        domProps: {
+                            value: t.rangeVal
+                        },
+                        on: {
+                            change: function(e) {
+                                return t.slideEmit()
+                            },
+                            __r: function(e) {
+                                t.rangeVal = e.target.value
+                            }
+                        }
+                    }), e("div", {
+                        staticClass: "range-value"
+                    }, [t._v(t._s(t.rangeVal) + " " + t._s(t.unit))])]), e("div", {
+                        staticClass: "min-max"
+                    }, [e("span", {
+                        staticClass: "min",
+                        attrs: {
+                            "aria-hidden": "true"
+                        }
+                    }, [t._v(t._s(t.minimum))]), e("span", {
+                        staticClass: "max",
+                        attrs: {
+                            "aria-hidden": "true"
+                        }
+                    }, [t._v(t._s(t.maximum))])])])
                 }
-            }), e("div", {
-                staticClass: "range-value"
-            }, [t._v(t._s(t.rangeVal) + " " + t._s(t.unit))])]), e("div", {
-                staticClass: "min-max"
-            }, [e("span", {
-                staticClass: "min",
-                attrs: {
-                    "aria-hidden": "true"
-                }
-            }, [t._v(t._s(t.minimum))]), e("span", {
-                staticClass: "max",
-                attrs: {
-                    "aria-hidden": "true"
-                }
-            }, [t._v(t._s(t.maximum))])])])
-        }
         )
-          , d = []
-          , u = {
+            , d = []
+            , u = {
             name: "RangeSlider",
             data: function() {
                 return {
@@ -500,88 +500,88 @@
                 }
             }
         }
-          , f = u
-          , p = (a("3398"),
-        a("2877"))
-          , h = Object(p["a"])(f, l, d, !1, null, "7796cc2c", null)
-          , m = h.exports
-          , v = a("b963")
-          , g = a("9ce6")
-          , C = a.n(g)
-          , _ = (a("b54a"),
-        function() {
-            var t = this
-              , e = t._self._c;
-            return e("div", {
-                staticClass: "notification"
-            }, [t.notification && !t.google ? e("div", {
-                staticClass: "not-google"
-            }, [e("div", {
-                staticClass: "top-text",
-                attrs: {
-                    tabindex: "0"
+            , f = u
+            , p = (a("3398"),
+            a("2877"))
+            , h = Object(p["a"])(f, l, d, !1, null, "7796cc2c", null)
+            , m = h.exports
+            , v = a("b963")
+            , g = a("9ce6")
+            , C = a.n(g)
+            , _ = (a("b54a"),
+                function() {
+                    var t = this
+                        , e = t._self._c;
+                    return e("div", {
+                        staticClass: "notification"
+                    }, [t.notification && !t.google ? e("div", {
+                        staticClass: "not-google"
+                    }, [e("div", {
+                        staticClass: "top-text",
+                        attrs: {
+                            tabindex: "0"
+                        }
+                    }, [e("h3", [t._v(t._s(t.notification.title))]), e("p", [t._v(t._s(t.notification.description))])]), e("div", {
+                        staticClass: "bottom-section",
+                        attrs: {
+                            tabindex: "0"
+                        }
+                    }, [e("a", {
+                        staticClass: "dismiss",
+                        attrs: {
+                            href: "/",
+                            "aria-label": "Dismiss"
+                        },
+                        on: {
+                            click: function(e) {
+                                return e.preventDefault(),
+                                    t.dismiss()
+                            }
+                        }
+                    }), t.notification.link ? e("a", {
+                        staticClass: "go-now",
+                        attrs: {
+                            href: t.notification.link,
+                            target: "_blank",
+                            "aria-label": "Go Now"
+                        }
+                    }) : t._e()])]) : t._e(), t.google ? e("div", {
+                        staticClass: "google"
+                    }, [t._m(0), e("div", {
+                        staticClass: "bottom-section"
+                    }, [e("a", {
+                        staticClass: "dismiss",
+                        attrs: {
+                            href: "/",
+                            "aria-label": "Dismiss"
+                        },
+                        on: {
+                            click: function(e) {
+                                return e.preventDefault(),
+                                    t.dismissGoogle()
+                            }
+                        }
+                    }), e("a", {
+                        staticClass: "go-now",
+                        attrs: {
+                            target: "_blank",
+                            href: "/delegate/service/initializeOauth2?nyuHomeUrl=".concat(t.path),
+                            "aria-label": "Authorize Application"
+                        }
+                    }), e("div", {
+                        staticClass: "google-image"
+                    })])]) : t._e()])
                 }
-            }, [e("h3", [t._v(t._s(t.notification.title))]), e("p", [t._v(t._s(t.notification.description))])]), e("div", {
-                staticClass: "bottom-section",
-                attrs: {
-                    tabindex: "0"
-                }
-            }, [e("a", {
-                staticClass: "dismiss",
-                attrs: {
-                    href: "/",
-                    "aria-label": "Dismiss"
-                },
-                on: {
-                    click: function(e) {
-                        return e.preventDefault(),
-                        t.dismiss()
-                    }
-                }
-            }), t.notification.link ? e("a", {
-                staticClass: "go-now",
-                attrs: {
-                    href: t.notification.link,
-                    target: "_blank",
-                    "aria-label": "Go Now"
-                }
-            }) : t._e()])]) : t._e(), t.google ? e("div", {
-                staticClass: "google"
-            }, [t._m(0), e("div", {
-                staticClass: "bottom-section"
-            }, [e("a", {
-                staticClass: "dismiss",
-                attrs: {
-                    href: "/",
-                    "aria-label": "Dismiss"
-                },
-                on: {
-                    click: function(e) {
-                        return e.preventDefault(),
-                        t.dismissGoogle()
-                    }
-                }
-            }), e("a", {
-                staticClass: "go-now",
-                attrs: {
-                    target: "_blank",
-                    href: "/delegate/service/initializeOauth2?nyuHomeUrl=".concat(t.path),
-                    "aria-label": "Authorize Application"
-                }
-            }), e("div", {
-                staticClass: "google-image"
-            })])]) : t._e()])
-        }
         )
-          , y = [function() {
+            , y = [function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 staticClass: "top-text"
             }, [e("h3", [t._v("CONNECT TO GOOGLE")]), e("p", [t._v("In order to display information from your Google Applications, NYU Home will need access to your NYU Google account. Link to your account?")])])
         }
         ]
-          , b = {
+            , b = {
             name: "CardNotification",
             props: {
                 notification: null,
@@ -609,127 +609,127 @@
                 dismiss: function() {
                     var t = new Date;
                     this.dismissed = t.toJSON(),
-                    this.$emit("dismiss", this.dismissed)
+                        this.$emit("dismiss", this.dismissed)
                 },
                 dismissGoogle: function() {
                     this.$emit("dismiss", !0)
                 }
             }
         }
-          , w = b
-          , T = (a("cf2a"),
-        Object(p["a"])(w, _, y, !1, null, "409cce4c", null))
-          , D = T.exports
-          , k = function() {
+            , w = b
+            , T = (a("cf2a"),
+            Object(p["a"])(w, _, y, !1, null, "409cce4c", null))
+            , D = T.exports
+            , k = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 staticClass: "feed-contain"
             }, [t.feed && t.feed.items.length > 0 ? e("ul", t._l(t.feed.items, (function(a, s) {
-                return e("li", {
-                    key: s
-                }, t._l(a.rows, (function(a, s) {
-                    return e("div", {
-                        key: s,
-                        staticClass: "row"
-                    }, t._l(a.fields, (function(a, s) {
-                        return e("div", {
-                            key: s,
-                            staticClass: "field",
-                            class: a.style,
-                            domProps: {
-                                innerHTML: t._s(t.generator(a))
-                            }
-                        })
-                    }
+                    return e("li", {
+                        key: s
+                    }, t._l(a.rows, (function(a, s) {
+                            return e("div", {
+                                key: s,
+                                staticClass: "row"
+                            }, t._l(a.fields, (function(a, s) {
+                                    return e("div", {
+                                        key: s,
+                                        staticClass: "field",
+                                        class: a.style,
+                                        domProps: {
+                                            innerHTML: t._s(t.generator(a))
+                                        }
+                                    })
+                                }
+                            )), 0)
+                        }
                     )), 0)
                 }
-                )), 0)
-            }
             )), 0) : t._e(), t.feed && !t.feed.items.length ? e("p", {
                 staticClass: "no-activity"
             }, [t._v("You currently have no activity.")]) : t._e()])
         }
-          , S = []
-          , A = (a("6b54"),
-        {
-            name: "GeneralFeed",
-            data: function() {
-                return {
-                    classes: null
-                }
-            },
-            props: {
-                feedType: null
-            },
-            computed: {
-                feed: function() {
-                    return this.$store.state.services.feeds && this.feedType ? this.$store.state.services.feeds[this.feedType] : []
-                }
-            },
-            methods: {
-                dateReceived: function(t, e) {
-                    var a = new Date(parseInt(t))
-                      , s = new Date
-                      , i = new Date(s.getFullYear(),s.getMonth(),s.getDate() - 7);
-                    if (!0 === e) {
-                        var n = a.getMonth() + 1
-                          , r = a.getDate()
-                          , o = a.getFullYear().toString().substring(2, 4)
-                          , c = a.getHours() > 11 ? "PM" : "AM"
-                          , l = (a.getHours() + 24) % 12 || 12
-                          , d = a.getMinutes()
-                          , u = d < 10 ? "0".concat(d) : d;
-                        return "".concat(n, "/").concat(r, "/").concat(o, " at ").concat(l, ":").concat(u, " ").concat(c)
+            , S = []
+            , A = (a("6b54"),
+            {
+                name: "GeneralFeed",
+                data: function() {
+                    return {
+                        classes: null
                     }
-                    if (a < i) {
-                        var f = a.getMonth() + 1
-                          , p = a.getDate()
-                          , h = a.getFullYear().toString().substring(2, 4);
-                        return "".concat(f, "/").concat(p, "/").concat(h)
-                    }
-                    if (s.getDay() == a.getDay() && s.getMonth() == a.getMonth()) {
-                        var m = a.getHours() > 11 ? "PM" : "AM"
-                          , v = (a.getHours() + 24) % 12 || 12
-                          , g = a.getMinutes()
-                          , C = g < 10 ? "0".concat(g) : g;
-                        return "".concat(v, ":").concat(C, " ").concat(m)
-                    }
-                    var _ = {
-                        weekday: "long"
-                    }
-                      , y = a.toLocaleDateString("en-US", _);
-                    return y
                 },
-                fieldFormatter: function(t) {
-                    if (t.url) {
-                        var e = '<a class="feed-link" href="'.concat(t.url, '" target="_blank">').concat(t.value, "</a>");
-                        return e
-                    }
-                    return t.value
+                props: {
+                    feedType: null
                 },
-                generator: function(t) {
-                    if ("receivedDate" == t.fieldName || "sortDate" == t.fieldName || "postDate" == t.fieldName) {
-                        var e = this.dateReceived(t.value, !1);
-                        return e
+                computed: {
+                    feed: function() {
+                        return this.$store.state.services.feeds && this.feedType ? this.$store.state.services.feeds[this.feedType] : []
                     }
-                    if ("dueDate" == t.fieldName || "availDate" == t.fieldName) {
-                        var a = this.dateReceived(t.value, !0);
-                        return a
+                },
+                methods: {
+                    dateReceived: function(t, e) {
+                        var a = new Date(parseInt(t))
+                            , s = new Date
+                            , i = new Date(s.getFullYear(),s.getMonth(),s.getDate() - 7);
+                        if (!0 === e) {
+                            var n = a.getMonth() + 1
+                                , r = a.getDate()
+                                , o = a.getFullYear().toString().substring(2, 4)
+                                , c = a.getHours() > 11 ? "PM" : "AM"
+                                , l = (a.getHours() + 24) % 12 || 12
+                                , d = a.getMinutes()
+                                , u = d < 10 ? "0".concat(d) : d;
+                            return "".concat(n, "/").concat(r, "/").concat(o, " at ").concat(l, ":").concat(u, " ").concat(c)
+                        }
+                        if (a < i) {
+                            var f = a.getMonth() + 1
+                                , p = a.getDate()
+                                , h = a.getFullYear().toString().substring(2, 4);
+                            return "".concat(f, "/").concat(p, "/").concat(h)
+                        }
+                        if (s.getDay() == a.getDay() && s.getMonth() == a.getMonth()) {
+                            var m = a.getHours() > 11 ? "PM" : "AM"
+                                , v = (a.getHours() + 24) % 12 || 12
+                                , g = a.getMinutes()
+                                , C = g < 10 ? "0".concat(g) : g;
+                            return "".concat(v, ":").concat(C, " ").concat(m)
+                        }
+                        var _ = {
+                            weekday: "long"
+                        }
+                            , y = a.toLocaleDateString("en-US", _);
+                        return y
+                    },
+                    fieldFormatter: function(t) {
+                        if (t.url) {
+                            var e = '<a class="feed-link" href="'.concat(t.url, '" target="_blank">').concat(t.value, "</a>");
+                            return e
+                        }
+                        return t.value
+                    },
+                    generator: function(t) {
+                        if ("receivedDate" == t.fieldName || "sortDate" == t.fieldName || "postDate" == t.fieldName) {
+                            var e = this.dateReceived(t.value, !1);
+                            return e
+                        }
+                        if ("dueDate" == t.fieldName || "availDate" == t.fieldName) {
+                            var a = this.dateReceived(t.value, !0);
+                            return a
+                        }
+                        var s = this.fieldFormatter(t);
+                        return s
                     }
-                    var s = this.fieldFormatter(t);
-                    return s
                 }
-            }
-        })
-          , x = A
-          , N = (a("b7fa"),
-        a("3366"),
-        Object(p["a"])(x, k, S, !1, null, "2609d4e1", null))
-          , O = N.exports
-          , E = function() {
+            })
+            , x = A
+            , N = (a("b7fa"),
+            a("3366"),
+            Object(p["a"])(x, k, S, !1, null, "2609d4e1", null))
+            , O = N.exports
+            , E = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 staticClass: "feed-contain"
             }, [e("ul", {
@@ -739,28 +739,28 @@
                     "data-timestamp": "Updated: 10:18 AM"
                 }
             }, t._l(t.feed.items, (function(a, s) {
-                return e("li", {
-                    key: s
-                }, [e("div", {
-                    staticClass: "feed-text"
-                }, [e("CalendarEvent", {
-                    staticClass: "calendar-item",
-                    attrs: {
-                        item: a
-                    },
-                    on: {
-                        update: function(e) {
-                            return t.sendConfirmation(a, e)
+                    return e("li", {
+                        key: s
+                    }, [e("div", {
+                        staticClass: "feed-text"
+                    }, [e("CalendarEvent", {
+                        staticClass: "calendar-item",
+                        attrs: {
+                            item: a
+                        },
+                        on: {
+                            update: function(e) {
+                                return t.sendConfirmation(a, e)
+                            }
                         }
-                    }
-                })], 1)])
-            }
+                    })], 1)])
+                }
             )), 0)])
         }
-          , R = []
-          , P = function() {
+            , R = []
+            , P = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 staticClass: "calendar-item clearfix"
             }, [e("div", {
@@ -824,8 +824,8 @@
                 staticClass: "feed-item"
             }, [t._v(" ")])])])
         }
-          , $ = []
-          , F = {
+            , $ = []
+            , F = {
             name: "CalendarEvent",
             data: function() {
                 return {
@@ -854,16 +854,16 @@
             methods: {
                 updateEventResponse: function(t) {
                     this.rsvp = t,
-                    this.$emit("update", t)
+                        this.$emit("update", t)
                 },
                 formatDate: function(t) {
                     var e = new Date(t)
-                      , a = e.getHours()
-                      , s = e.getMinutes()
-                      , i = a >= 12 ? "pm" : "am";
+                        , a = e.getHours()
+                        , s = e.getMinutes()
+                        , i = a >= 12 ? "pm" : "am";
                     a %= 12,
-                    a = a || 12,
-                    s = s < 10 ? "0" + s : s;
+                        a = a || 12,
+                        s = s < 10 ? "0" + s : s;
                     var n = a + ":" + s + " " + i;
                     return n
                 },
@@ -871,16 +871,16 @@
                     if (a)
                         return "All Day";
                     var s = this.formatDate(t)
-                      , i = this.formatDate(e)
-                      , n = s + " - " + i;
+                        , i = this.formatDate(e)
+                        , n = s + " - " + i;
                     return n
                 },
                 formatCalendarFeedDate: function(t) {
                     var e = new Date(t)
-                      , a = new Date
-                      , s = new Date(a.getFullYear(),a.getMonth(),a.getDate() + 7)
-                      , i = (new Date(e),
-                    "");
+                        , a = new Date
+                        , s = new Date(a.getFullYear(),a.getMonth(),a.getDate() + 7)
+                        , i = (new Date(e),
+                        "");
                     if (e > s) {
                         var n = {
                             year: "numeric",
@@ -902,29 +902,29 @@
                 },
                 displayAlert: function(t) {
                     var e = new Date
-                      , a = new Date
-                      , s = new Date(t.startTime)
-                      , i = new Date(t.endTime);
+                        , a = new Date
+                        , s = new Date(t.startTime)
+                        , i = new Date(t.endTime);
                     return a.setMinutes(a.getMinutes() + 60),
                     a > s || e > s && e < i
                 },
                 displayAlertText: function(t) {
                     var e = new Date
-                      , a = new Date(t.startTime)
-                      , s = new Date(t.endTime);
+                        , a = new Date(t.startTime)
+                        , s = new Date(t.endTime);
                     if (e > a && e < s)
                         return "NOW";
                     var i = a.getTime() - e.getTime()
-                      , n = i / 6e4;
+                        , n = i / 6e4;
                     return Math.round(n) + " MIN"
                 }
             }
         }
-          , M = F
-          , I = (a("a813"),
-        Object(p["a"])(M, P, $, !1, null, "13dc15f7", null))
-          , z = I.exports
-          , j = {
+            , M = F
+            , I = (a("a813"),
+            Object(p["a"])(M, P, $, !1, null, "13dc15f7", null))
+            , z = I.exports
+            , j = {
             name: "CalendarFeed",
             components: {
                 CalendarEvent: z
@@ -945,16 +945,16 @@
             methods: {
                 sendConfirmation: function(t, e) {
                     t.responseStatus = e,
-                    this.$store.dispatch("sendConfirmation", t)
+                        this.$store.dispatch("sendConfirmation", t)
                 },
                 formatDate: function(t) {
                     var e = new Date(t)
-                      , a = e.getHours()
-                      , s = e.getMinutes()
-                      , i = a >= 12 ? "pm" : "am";
+                        , a = e.getHours()
+                        , s = e.getMinutes()
+                        , i = a >= 12 ? "pm" : "am";
                     a %= 12,
-                    a = a || 12,
-                    s = s < 10 ? "0" + s : s;
+                        a = a || 12,
+                        s = s < 10 ? "0" + s : s;
                     var n = a + ":" + s + " " + i;
                     return n
                 },
@@ -962,16 +962,16 @@
                     if (a)
                         return "All Day";
                     var s = this.formatDate(t)
-                      , i = this.formatDate(e)
-                      , n = s + " - " + i;
+                        , i = this.formatDate(e)
+                        , n = s + " - " + i;
                     return n
                 },
                 formatCalendarFeedDate: function(t) {
                     var e = new Date(t)
-                      , a = new Date
-                      , s = new Date(a.getFullYear(),a.getMonth(),a.getDate() + 7)
-                      , i = (new Date(e),
-                    "");
+                        , a = new Date
+                        , s = new Date(a.getFullYear(),a.getMonth(),a.getDate() + 7)
+                        , i = (new Date(e),
+                        "");
                     if (e > s) {
                         var n = {
                             year: "numeric",
@@ -993,42 +993,42 @@
                 },
                 displayAlert: function(t) {
                     var e = new Date
-                      , a = new Date
-                      , s = new Date(t.startTime)
-                      , i = new Date(t.endTime);
+                        , a = new Date
+                        , s = new Date(t.startTime)
+                        , i = new Date(t.endTime);
                     return a.setMinutes(a.getMinutes() + 60),
                     a > s || e > s && e < i
                 },
                 displayAlertText: function(t) {
                     var e = new Date
-                      , a = new Date(t.startTime)
-                      , s = new Date(t.endTime);
+                        , a = new Date(t.startTime)
+                        , s = new Date(t.endTime);
                     if (e > a && e < s)
                         return "NOW";
                     var i = a.getTime() - e.getTime()
-                      , n = i / 6e4;
+                        , n = i / 6e4;
                     return Math.round(n) + " MIN"
                 }
             }
         }
-          , V = j
-          , L = (a("5749"),
-        a("cf5a"),
-        Object(p["a"])(V, E, R, !1, null, "6140aeae", null))
-          , H = L.exports
-          , U = (a("b047c"),
-        a("b238"))
-          , G = function() {
+            , V = j
+            , L = (a("5749"),
+            a("cf5a"),
+            Object(p["a"])(V, E, R, !1, null, "6140aeae", null))
+            , H = L.exports
+            , U = (a("b047c"),
+            a("b238"))
+            , G = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("button", t._g({
-                staticClass: "favorite",
-                attrs: {
-                    id: "nyu_btn-favorite",
-                    tabindex: "0",
-                    "aria-pressed": t.favorited
-                }
-            }, t.$listeners), [e("svg", {
+                                        staticClass: "favorite",
+                                        attrs: {
+                                            id: "nyu_btn-favorite",
+                                            tabindex: "0",
+                                            "aria-pressed": t.favorited
+                                        }
+                                    }, t.$listeners), [e("svg", {
                 class: {
                     favorited: t.favorited
                 },
@@ -1049,8 +1049,8 @@
                 }
             })])])
         }
-          , Y = []
-          , B = {
+            , Y = []
+            , B = {
             name: "FavoriteButton",
             props: {
                 favorited: {
@@ -1059,32 +1059,32 @@
                 }
             }
         }
-          , q = B
-          , J = (a("f3d0"),
-        Object(p["a"])(q, G, Y, !1, null, "062afdab", null))
-          , W = J.exports
-          , Z = a("0c85")
-          , X = function() {
+            , q = B
+            , J = (a("f3d0"),
+            Object(p["a"])(q, G, Y, !1, null, "062afdab", null))
+            , W = J.exports
+            , Z = a("0c85")
+            , X = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 staticClass: "settings-container",
                 attrs: {
                     tabindex: "-1"
                 }
             }, [e("svg", t._g({
-                staticClass: "settings",
-                attrs: {
-                    tabindex: "0",
-                    viewBox: "-4 5 45 25.3",
-                    width: "45",
-                    height: "25.3",
-                    id: "src--main--webapp--images--raw-svgs--nyu_btn-settings",
-                    y: "525",
-                    version: "1.1",
-                    role: "button"
-                }
-            }, t.$listeners), [e("g", {
+                                  staticClass: "settings",
+                                  attrs: {
+                                      tabindex: "0",
+                                      viewBox: "-4 5 45 25.3",
+                                      width: "45",
+                                      height: "25.3",
+                                      id: "src--main--webapp--images--raw-svgs--nyu_btn-settings",
+                                      y: "525",
+                                      version: "1.1",
+                                      role: "button"
+                                  }
+                              }, t.$listeners), [e("g", {
                 attrs: {
                     fill: "#559ACD",
                     id: "g4780"
@@ -1096,15 +1096,15 @@
                 }
             })])])])
         }
-          , K = []
-          , Q = {
+            , K = []
+            , Q = {
             name: "SettingsButton"
         }
-          , tt = Q
-          , et = (a("28ab"),
-        Object(p["a"])(tt, X, K, !1, null, "1c65b77e", null))
-          , at = et.exports
-          , st = {
+            , tt = Q
+            , et = (a("28ab"),
+            Object(p["a"])(tt, X, K, !1, null, "1c65b77e", null))
+            , at = et.exports
+            , st = {
             name: "BasicCard",
             components: {
                 ActionNotice: o["a"],
@@ -1150,7 +1150,7 @@
             },
             beforeDestroy: function() {
                 clearInterval(this.googleTimer),
-                clearInterval(this.classTimer)
+                    clearInterval(this.classTimer)
             },
             computed: {
                 user: function() {
@@ -1214,52 +1214,52 @@
                 },
                 flipCard: function() {
                     this.flipped = !this.flipped,
-                    this.$refs.container.focus()
+                        this.$refs.container.focus()
                 },
                 shrinkSection: function(t, e) {
                     e.userSectionState.collapsed = t,
-                    this.$store.dispatch("postSectionSettings", e)
+                        this.$store.dispatch("postSectionSettings", e)
                 },
                 shrinkCard: function() {
                     this.cardProps.userSettings.collapsed = !this.cardProps.userSettings.collapsed,
-                    this.$store.dispatch("cardSettings", this.content),
-                    this.$refs.container.focus()
+                        this.$store.dispatch("cardSettings", this.content),
+                        this.$refs.container.focus()
                 },
                 favoriteCard: function() {
                     this.cardProps.userSettings.favorite = !this.cardProps.userSettings.favorite,
-                    this.fav = this.cardProps.userSettings.favorite,
-                    this.$store.dispatch("cardSettings", this.content),
-                    this.$refs.container.focus()
+                        this.fav = this.cardProps.userSettings.favorite,
+                        this.$store.dispatch("cardSettings", this.content),
+                        this.$refs.container.focus()
                 },
                 dismissNotification: function(t) {
                     this.content.userSettings.notificationDismissed = t,
-                    this.content.notification = null,
-                    this.$store.dispatch("cardSettings", this.content)
+                        this.content.notification = null,
+                        this.$store.dispatch("cardSettings", this.content)
                 },
                 dismissGoogleNotification: function(t) {
                     this.googleNotificationDismissed = t,
-                    this.$store.dispatch("dismissGoogle", t)
+                        this.$store.dispatch("dismissGoogle", t)
                 },
                 openFeed: function(t) {
                     this.cardProps.userSettings.feedCollapsed = t,
-                    this.$store.dispatch("cardSettings", this.content)
+                        this.$store.dispatch("cardSettings", this.content)
                 },
                 changeFeed: function(t) {
                     this.cardProps.userSettings.maxVisibleItems = t,
-                    this.$store.dispatch("cardSettings", this.content)
+                        this.$store.dispatch("cardSettings", this.content)
                 }
             }
         }
-          , it = st
-          , nt = (a("0339"),
-        a("8a67"),
-        Object(p["a"])(it, n, r, !1, null, "10f700a6", null))
-          , rt = nt.exports
-          , ot = a("abad")
-          , ct = a("f344")
-          , lt = function() {
+            , it = st
+            , nt = (a("0339"),
+            a("8a67"),
+            Object(p["a"])(it, n, r, !1, null, "10f700a6", null))
+            , rt = nt.exports
+            , ot = a("abad")
+            , ct = a("f344")
+            , lt = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", [t.searchResults && "" != t.searchResults ? e("div", {
                 staticClass: "search"
             }, ["search" == t.viewType ? e("h3", {
@@ -1282,23 +1282,23 @@
                     gutter: 30
                 }
             }, [t._l(t.searchResults, (function(a) {
-                return ["promo" != a.cardType && "librariestype" != a.cardType ? e("basic-card", {
-                    key: a.id,
-                    attrs: {
-                        content: a
-                    }
-                }) : t._e(), "promo" == a.cardType ? e("tutorial-card", {
-                    key: a.id,
-                    attrs: {
-                        content: a.notification
-                    }
-                }) : t._e(), "librariestype" == a.cardType ? e("library-card", {
-                    key: a.id,
-                    attrs: {
-                        content: a
-                    }
-                }) : t._e()]
-            }
+                    return ["promo" != a.cardType && "librariestype" != a.cardType ? e("basic-card", {
+                        key: a.id,
+                        attrs: {
+                            content: a
+                        }
+                    }) : t._e(), "promo" == a.cardType ? e("tutorial-card", {
+                        key: a.id,
+                        attrs: {
+                            content: a.notification
+                        }
+                    }) : t._e(), "librariestype" == a.cardType ? e("library-card", {
+                        key: a.id,
+                        attrs: {
+                            content: a
+                        }
+                    }) : t._e()]
+                }
             ))], 2)], 1) : t.notAuthorized ? e("h1", {
                 staticClass: "no-cards"
             }, [t._v("YOU DO NOT HAVE PERMISSION TO VIEW THIS CARD.")]) : e("h1", {
@@ -1311,9 +1311,9 @@
                 staticClass: "blue"
             }, [t._v(" You may be able to find what you're looking for at one of these links:")]), t._m(0)])])
         }
-          , dt = [function() {
+            , dt = [function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("ul", [e("li", [e("a", {
                 staticClass: "blue",
                 attrs: {
@@ -1353,27 +1353,27 @@
             }, [t._v("NYU News")])])])
         }
         ]
-          , ut = function() {
+            , ut = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("basic-card", {
                 attrs: {
                     content: t.content
                 }
             }, [e("library-search-embed")], 1)
         }
-          , ft = []
-          , pt = function() {
+            , ft = []
+            , pt = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("div", {
                 attrs: {
                     id: "primo_explore_search_embed_container_nyu"
                 }
             })
         }
-          , ht = []
-          , mt = {
+            , ht = []
+            , mt = {
             name: "LibrarySearch",
             props: {
                 content: null
@@ -1381,15 +1381,15 @@
             beforeCreate: function() {
                 var t = document.createElement("script");
                 t.type = "text/javascript",
-                t.setAttribute("src", "https://cdn-dev.library.nyu.edu/bess-vue/app.min.js?institution=NYU_HOME&element_id=primo_explore_search_embed_container_nyu"),
-                document.body.appendChild(t)
+                    t.setAttribute("src", "https://cdn-dev.library.nyu.edu/bess-vue/app.min.js?institution=NYU_HOME&element_id=primo_explore_search_embed_container_nyu"),
+                    document.body.appendChild(t)
             }
         }
-          , vt = mt
-          , gt = (a("df39"),
-        Object(p["a"])(vt, pt, ht, !1, null, null, null))
-          , Ct = gt.exports
-          , _t = {
+            , vt = mt
+            , gt = (a("df39"),
+            Object(p["a"])(vt, pt, ht, !1, null, null, null))
+            , Ct = gt.exports
+            , _t = {
             name: "LibraryCard",
             components: {
                 BasicCard: rt,
@@ -1406,10 +1406,10 @@
                 }
             }
         }
-          , yt = _t
-          , bt = Object(p["a"])(yt, ut, ft, !1, null, null, null)
-          , wt = bt.exports
-          , Tt = {
+            , yt = _t
+            , bt = Object(p["a"])(yt, ut, ft, !1, null, null, null)
+            , wt = bt.exports
+            , Tt = {
             name: "SearchResults",
             components: {
                 BasicCard: rt,
@@ -1448,22 +1448,22 @@
             methods: {
                 getResults: function() {
                     var t = this
-                      , e = this.$route.params.viewType
-                      , a = this.$route.params.searchTermOrID;
+                        , e = this.$route.params.viewType
+                        , a = this.$route.params.searchTermOrID;
                     "card" == e ? this.$store.dispatch("findCardSingle", a) : "search" == e && this.$store.dispatch("getSearchResults", a).then((function() {
-                        t.$store.dispatch("setSearchForDisplay")
-                    }
-                    ))
+                            t.$store.dispatch("setSearchForDisplay")
+                        }
+                                                                                                                                                ))
                 }
             }
         }
-          , Dt = Tt
-          , kt = (a("6ea3"),
-        Object(p["a"])(Dt, lt, dt, !1, null, "2ef1c3d0", null))
-          , St = kt.exports
-          , At = function() {
+            , Dt = Tt
+            , kt = (a("6ea3"),
+            Object(p["a"])(Dt, lt, dt, !1, null, "2ef1c3d0", null))
+            , St = kt.exports
+            , At = function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return t.showError ? e("div", {
                 staticClass: "error-contain"
             }, [e("span", {
@@ -1477,9 +1477,9 @@
                 }
             }, [t._v("✖")])]) : t._e()
         }
-          , xt = [function() {
+            , xt = [function() {
             var t = this
-              , e = t._self._c;
+                , e = t._self._c;
             return e("p", [t._v("Please try your request again.  If the problem persists, you can "), e("a", {
                 attrs: {
                     target: "_blank",
@@ -1493,7 +1493,7 @@
             }, [t._v("contact the IT Service Desk")]), t._v(".")])
         }
         ]
-          , Nt = {
+            , Nt = {
             name: "HttpError",
             computed: {
                 showError: function() {
@@ -1503,17 +1503,17 @@
             methods: {
                 closeError: function() {
                     this.$store.state.people.generalError = !1,
-                    this.$store.state.services.generalError = !1,
-                    this.$store.state.profile.generalError = !1
+                        this.$store.state.services.generalError = !1,
+                        this.$store.state.profile.generalError = !1
                 }
             }
         }
-          , Ot = Nt
-          , Et = (a("dad8"),
-        Object(p["a"])(Ot, At, xt, !1, null, "195996a3", null))
-          , Rt = Et.exports
-          , Pt = a("9bd9")
-          , $t = {
+            , Ot = Nt
+            , Et = (a("dad8"),
+            Object(p["a"])(Ot, At, xt, !1, null, "195996a3", null))
+            , Rt = Et.exports
+            , Pt = a("9bd9")
+            , $t = {
             name: "service",
             components: {
                 DraggableCustomize: Pt["a"],
@@ -1552,7 +1552,7 @@
             watch: {
                 $route: function() {
                     "search" == this.$route.params.viewType || "card" == this.$route.params.viewType ? this.showSearch = !0 : (this.showSearch = !1,
-                    this.$route.params.viewType ? this.$store.dispatch("getCards", this.$route.params.viewType.toUpperCase()) : this.$store.dispatch("getCards", "FAVORITES"))
+                        this.$route.params.viewType ? this.$store.dispatch("getCards", this.$route.params.viewType.toUpperCase()) : this.$store.dispatch("getCards", "FAVORITES"))
                 }
             },
             methods: {
@@ -1562,14 +1562,14 @@
                             var t = new Date((new Date).setFullYear((new Date).getFullYear() - 1));
                             return t.toJSON()
                         }
-                          , a = function() {
+                            , a = function() {
                             var t = new Date((new Date).setFullYear((new Date).getFullYear() + 1));
                             return t.toJSON()
                         }
-                          , s = (new Date).toJSON()
-                          , i = t.notification.beginDate ? t.notification.beginDate : e()
-                          , n = t.notification.endDate ? t.notification.endDate : a()
-                          , r = t.userSettings.notificationDismissed;
+                            , s = (new Date).toJSON()
+                            , i = t.notification.beginDate ? t.notification.beginDate : e()
+                            , n = t.notification.endDate ? t.notification.endDate : a()
+                            , r = t.userSettings.notificationDismissed;
                         return !!r && (i < r && r < n || s > n)
                     }
                     return !1
@@ -1579,9 +1579,9 @@
                 }
             }
         }
-          , Ft = $t
-          , Mt = (a("25f8"),
-        Object(p["a"])(Ft, s, i, !1, null, "c6189efc", null));
+            , Ft = $t
+            , Mt = (a("25f8"),
+            Object(p["a"])(Ft, s, i, !1, null, "c6189efc", null));
         e["default"] = Mt.exports
     },
     f3d0: function(t, e, a) {

--- a/browser-overrides/globalhome.nyu.edu/services/search/libraries
+++ b/browser-overrides/globalhome.nyu.edu/services/search/libraries
@@ -1,531 +1,86 @@
-<html lang="en">
-<script async=""
-        src="https://www.googletagmanager.com/gtm.js?id=GTM-KQB54DT"></script>
-<head>
-    <script>(
-        function ( w, d, s, l, i ) {
-            w[ l ] = w[ l ] || [];
-            w[ l ].push( {
-                             "gtm.start" : new Date().getTime(),
-                             event       : "gtm.js"
-                         } );
-            var f = d.getElementsByTagName( s )[ 0 ],
-                j = d.createElement( s ),
-                dl = l != "dataLayer" ? "&l=" + l : "";
-            j.async = true;
-            j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-            f.parentNode.insertBefore( j, f );
-        }
-    )( window, document, "script", "dataLayer", "GTM-KQB54DT" );</script>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="icon" atype="image/x-icon" href="/img/icons/favicon.png">
-    <title>[LOCAL OVERRIDE] NYU Home</title>
-    <link href="/css/chunk-0aa6f7d1.f9513408.css" rel="prefetch">
-    <link href="/css/chunk-1b8610b0.60cb00ee.css" rel="prefetch">
-    <link href="/css/chunk-2664ac6e.f8043fd4.css" rel="prefetch">
-    <link href="/css/chunk-27d4e252.7190c220.css" rel="prefetch">
-    <link href="/css/chunk-30b6a859.199073aa.css" rel="prefetch">
-    <link href="/css/chunk-4165a38f.abf40978.css" rel="prefetch">
-    <link href="/css/chunk-557bd6d4.642c5549.css" rel="prefetch">
-    <link href="/css/chunk-5aea712e.46902ed0.css" rel="prefetch">
-    <link href="/css/chunk-5d01dde2.5ba01fad.css" rel="prefetch">
-    <link href="/css/chunk-712a5866.7fc3ef64.css" rel="prefetch">
-    <link href="/css/chunk-71e07923.d70331af.css" rel="prefetch">
-    <link href="/css/chunk-75a09bb0.baad4a65.css" rel="prefetch">
-    <link href="/css/chunk-87120890.b01a8de9.css" rel="prefetch">
-    <link href="/css/chunk-95d628be.737bb96a.css" rel="prefetch">
-    <link href="/css/chunk-9beb8a10.94f9219b.css" rel="prefetch">
-    <link href="/css/chunk-a25f5f94.598309db.css" rel="prefetch">
-    <link href="/css/chunk-a343a752.df0c128f.css" rel="prefetch">
-    <link href="/css/chunk-ab6da9ba.26805fd0.css" rel="prefetch">
-    <link href="/css/chunk-d1354d08.177f5c6f.css" rel="prefetch">
-    <link href="/css/chunk-da0d8a4c.23f5805a.css" rel="prefetch">
-    <link href="/css/chunk-f0b7e896.4dbbd892.css" rel="prefetch">
-    <link href="/css/common.d53bf2b0.css" rel="prefetch">
-    <link href="/js/chunk-0aa6f7d1.37912733.js" rel="prefetch">
-    <link href="/js/chunk-1b8610b0.349923ea.js" rel="prefetch">
-    <link href="/js/chunk-2664ac6e.29e0ee2c.js" rel="prefetch">
-    <link href="/js/chunk-27d4e252.1551654d.js" rel="prefetch">
-    <link href="/js/chunk-2d0daf2f.ebf1ccda.js" rel="prefetch">
-    <link href="/js/chunk-30b6a859.c36a3715.js" rel="prefetch">
-    <link href="/js/chunk-4165a38f.089c1895.js" rel="prefetch">
-    <link href="/js/chunk-557bd6d4.17146a8e.js" rel="prefetch">
-    <link href="/js/chunk-5aea712e.d59117e2.js" rel="prefetch">
-    <link href="/js/chunk-5d01dde2.f40f172a.js" rel="prefetch">
-    <link href="/js/chunk-712a5866.cf180191.js" rel="prefetch">
-    <link href="/js/chunk-71e07923.ffa51d2e.js" rel="prefetch">
-    <link href="/js/chunk-75a09bb0.e76b6225.js" rel="prefetch">
-    <link href="/js/chunk-87120890.4e0fae91.js" rel="prefetch">
-    <link href="/js/chunk-95d628be.1f231702.js" rel="prefetch">
-    <link href="/js/chunk-9beb8a10.dbc23858.js" rel="prefetch">
-    <link href="/js/chunk-a25f5f94.d6e3d69f.js" rel="prefetch">
-    <link href="/js/chunk-a343a752.8b32a484.js" rel="prefetch">
-    <link href="/js/chunk-ab6da9ba.3206bdab.js" rel="prefetch">
-    <link href="/js/chunk-d1354d08.4d5429e2.js" rel="prefetch">
-    <link href="/js/chunk-da0d8a4c.25e73775.js" rel="prefetch">
-    <link href="/js/chunk-f0b7e896.f8915de0.js" rel="prefetch">
-    <link href="/js/common.39469e5a.js" rel="prefetch">
-    <link href="/css/app.911e0180.css" rel="preload" as="style">
-    <link href="/js/app.0aa7cc41.js" rel="preload" as="script">
-    <link href="/js/chunk-vendors.39dbf672.js" rel="preload" as="script">
-    <link href="/css/app.911e0180.css" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="/css/common.d53bf2b0.css">
-    <script charset="utf-8" src="/js/common.39469e5a.js"></script>
-    <link rel="stylesheet" type="text/css"
-          href="/css/chunk-ab6da9ba.26805fd0.css">
-    <script charset="utf-8" src="/js/chunk-ab6da9ba.3206bdab.js"></script>
-    <link rel="stylesheet" type="text/css"
-          href="/css/chunk-557bd6d4.642c5549.css">
-    <script charset="utf-8" src="/js/chunk-557bd6d4.17146a8e.js"></script>
-</head>
-<body class="js-focus-visible">
-<noscript>
-    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQB54DT"
-            height=0 width=0 style=display:none;visibility:hidden></iframe>
-</noscript>
-<noscript><strong>We're sorry but nyu doesn't work properly without JavaScript
-    enabled. Please enable it to continue.</strong></noscript>
-<div data-v-c14b7b78="" id="app" class="container"><!----><!---->
-    <nav data-v-c14b7b78="" aria-label="Accessibility Navigation Assistant"
-         aria-keyshortcuts="Ctrl+/" tabindex="0" class="acc-nav">
-        <div class="acc-nav__wrapper" style="display: none;">
-            <div class="dropdown"><select id="landmarks" name="landmarks"
-                                          aria-haspopup="true"
-                                          aria-expanded="false"
-                                          aria-label="Select from dropdown to jump to sections of this page"
-                                          tabindex="0">
-                <option value="" selected="selected">Sections of this page
-                </option>
-                <option value="main-content">Main Content</option>
-                <option value="side-nav">Side Navigation</option>
-                <option value="side-nav">Footer</option>
-            </select></div>
-            <div aria-label="Press Control Slash to open this menu."
-                 aria-live="assertive" tabindex="-1" class="instructions">Press
-                <span class="key">ctrl</span> +
-                <span class="key">/</span> to open this menu
-            </div>
-        </div>
-    </nav><!---->
-    <div data-v-c7a7958a="" data-v-c14b7b78="" id="container" class="">
-        <div data-v-c7a7958a="" class="mobile-nav">
-            <div data-v-20680f76="" data-v-c7a7958a=""
-                 class="mobile-nav-contain">
-                <nav data-v-20680f76="" aria-label="Mobile Navigation"><a
-                        data-v-20680f76="" href="/"
-                        class="mobile-logo router-link-active"
-                        aria-label="NYU Home"></a><a data-v-20680f76=""
-                                                     href="/services"
-                                                     class="mobileprod-link first router-link-active">SERVICES</a><a
-                        data-v-20680f76="" href="/people"
-                        class="mobileprod-link">PEOPLE</a>
-                    <ul data-v-20680f76="">
-                        <li data-v-20680f76=""><a data-v-20680f76=""
-                                                  href="/services/favorites"
-                                                  class="">Favorites
-                            <span data-v-20680f76="" class="notification-count">1</span></a>
-                        </li>
-                        <li data-v-20680f76=""><a data-v-20680f76=""
-                                                  href="/services/academics"
-                                                  class="">Academics
-                            <span data-v-20680f76="" class="notification-count">3</span></a>
-                        </li>
-                        <li data-v-20680f76=""><a data-v-20680f76=""
-                                                  href="/services/work"
-                                                  class="">Work
-                            <span data-v-20680f76="" class="notification-count">6</span></a>
-                        </li>
-                        <li data-v-20680f76=""><a data-v-20680f76=""
-                                                  href="/services/research"
-                                                  class="">Research
-                            <!----></a></li>
-                        <li data-v-20680f76=""><a data-v-20680f76=""
-                                                  href="/services/life"
-                                                  class="">NYU Life
-                            <!----></a></li>
-                    </ul><!---->
-                    <div data-v-20680f76="" class="footer-container">
-                        <section data-v-4ecc9394="" data-v-20680f76=""
-                                 role="contentinfo">
-                            <ul data-v-4ecc9394="">
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          target="_blank"
-                                                          href="https://nyu.service-now.com/servicelink/kb_search.do?id=KB0013697">About
-                                    NYUHome</a></li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          href="/tips" class="">Tips
-                                    and Getting Started</a></li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          href="/feedback"
-                                                          class="">Feedback</a>
-                                </li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          target="_blank"
-                                                          href="https://www.nyu.edu/footer/accessibility.html">Accessibility</a>
-                                </li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          target="_blank"
-                                                          href="https://www.nyu.edu/life/information-technology/help-and-service-status/nyu-it-service-desk.html">IT
-                                    Service Desk</a></li>
-                            </ul>
-                            <p data-v-4ecc9394="">
-                                Copyright 1999-2024
-                                <br data-v-4ecc9394="">New York University
-                            </p></section>
-                    </div>
-                </nav>
-            </div>
-        </div>
-        <div data-v-364ae36a="" data-v-c7a7958a="" role="banner" id="topbar"
-             class="topbar">
-            <div data-v-364ae36a="" class="topbar-contain">
-                <div data-v-364ae36a="" class="hamburger"></div>
-                <a data-v-364ae36a="" href="https://www.nyu.edu/"
-                   aria-label="NYU Home" class="logo"></a>
-                <div data-v-364ae36a="" class="section">Search</div>
-                <div data-v-3666c3f5="" data-v-364ae36a="" class="profile">
-                    <div data-v-3666c3f5=""><span data-v-3666c3f5=""
-                                                  aria-label="You are logged in as David Arjanik"
-                                                  class="user-name">David Arjanik</span>
-                        <div data-v-3666c3f5="" class="image-contain">
-                            <button data-v-3666c3f5=""
-                                    aria-label="Toggle Profile Menu"
-                                    class="initial proflile-image">D
-                            </button>
-                            <div data-v-3666c3f5="" class="image proflile-image"
-                                 style="background-image: url(&quot;/api/profile/image/da70&quot;);"></div>
-                        </div>
-                        <div data-v-3666c3f5="" class="container"
-                             style="display: none;">
-                            <ul data-v-3666c3f5="">
-                                <li data-v-3666c3f5=""><a data-v-3666c3f5=""
-                                                          href="/settings"
-                                                          class="">Settings</a>
-                                </li><!----><!----><!----><!----><!---->
-                                <li data-v-3666c3f5=""><a data-v-3666c3f5=""
-                                                          href="/logout"
-                                                          class="logout">LOG
-                                    OUT</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div data-v-c7a7958a="" class="menu-with-title">
-            <div data-v-c7a7958a="" class="menu-with-title-content">
-                <div data-v-c7a7958a=""
-                     style="position: relative; height: 0px; max-height: 0px;">
-                    <div data-v-c7a7958a="" class="search-bar-container">
-                        <div data-v-c7a7958a="" id="search"
-                             class="searchContain"><input id="nyu-search-input"
-                                                          type="text"
-                                                          name="term"
-                                                          aria-autocomplete="list"
-                                                          autocomplete="off"
-                                                          placeholder="Search NYU Services"
-                                                          aria-label="Search NYU Services"
-                                                          aria-haspopup="listbox"
-                                                          role="search"
-                                                          class="channelsearch">
-                            <!---->
-                            <button id="nyu-channel-search-button"
-                                    class="searchButton hide-text"><span
-                                    class="search-button-icon"></span> Search
-                            </button>
-                        </div><!----></div>
-                </div>
-                <h1 data-v-c7a7958a="" class="page-title"><a data-v-c7a7958a=""
-                                                             href="/"
-                                                             class="title router-link-active">NYUHome</a>
-                </h1>
-                <div data-v-c7a7958a="" class="sections">
-                    <div data-v-c7a7958a="" id="productNav" class="prod-row">
-                        <div data-v-c7a7958a="" id="productNav-default"
-                             role="navigation">
-                            <ul data-v-c7a7958a="">
-                                <li data-v-c7a7958a=""><a data-v-c7a7958a=""
-                                                          href="/services"
-                                                          aria-current="page"
-                                                          class="title router-link-active">Services</a>
-                                </li>
-                                <li data-v-c7a7958a=""><a data-v-c7a7958a=""
-                                                          href="/people"
-                                                          class="title">People</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div data-v-c7a7958a="" id="main-content" tabindex="0" role="main">
-                <div data-v-c7a7958a="" class="main-content">
-                    <nav data-v-05fdf969="" data-v-c7a7958a="" id="side-nav"
-                         tabindex="0" class="side-nav">
-                        <ul data-v-05fdf969="">
-                            <li data-v-05fdf969=""><a data-v-05fdf969=""
-                                                      href="/services/favorites"
-                                                      class="">
-                                Favorites
-                                <span data-v-05fdf969=""
-                                      class="notification-count">1</span></a>
-                            </li>
-                            <li data-v-05fdf969=""><a data-v-05fdf969=""
-                                                      href="/services/academics"
-                                                      class="">
-                                Academics
-                                <span data-v-05fdf969=""
-                                      class="notification-count">3</span></a>
-                            </li>
-                            <li data-v-05fdf969=""><a data-v-05fdf969=""
-                                                      href="/services/work"
-                                                      class="">
-                                Work
-                                <span data-v-05fdf969=""
-                                      class="notification-count">6</span></a>
-                            </li>
-                            <li data-v-05fdf969=""><a data-v-05fdf969=""
-                                                      href="/services/research"
-                                                      class="">
-                                Research
-                                <!----></a></li>
-                            <li data-v-05fdf969=""><a data-v-05fdf969=""
-                                                      href="/services/life"
-                                                      class="">
-                                NYU Life
-                                <!----></a></li>
-                        </ul><!---->
-                        <section data-v-4ecc9394="" data-v-05fdf969=""
-                                 role="contentinfo">
-                            <ul data-v-4ecc9394="">
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          target="_blank"
-                                                          href="https://nyu.service-now.com/servicelink/kb_search.do?id=KB0013697">About
-                                    NYUHome</a></li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          href="/tips" class="">Tips
-                                    and Getting Started</a></li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          href="/feedback"
-                                                          class="">Feedback</a>
-                                </li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          target="_blank"
-                                                          href="https://www.nyu.edu/footer/accessibility.html">Accessibility</a>
-                                </li>
-                                <li data-v-4ecc9394=""><a data-v-4ecc9394=""
-                                                          target="_blank"
-                                                          href="https://www.nyu.edu/life/information-technology/help-and-service-status/nyu-it-service-desk.html">IT
-                                    Service Desk</a></li>
-                            </ul>
-                            <p data-v-4ecc9394="">
-                                Copyright 1999-2024
-                                <br data-v-4ecc9394="">New York University
-                            </p></section>
-                    </nav>
-                    <div data-v-c7a7958a="" class="cards">
-                        <div data-v-c6189efc="" data-v-c7a7958a="" class="home">
-                            <!----><!---->
-                            <div data-v-c6189efc="">
-                                <div data-v-2ef1c3d0="" data-v-c6189efc="">
-                                    <div data-v-2ef1c3d0="" class="search"><h3
-                                            data-v-2ef1c3d0="" role="status"
-                                            aria-live="polite"><span
-                                            data-v-2ef1c3d0="" class="big blue">1 SEARCH RESULT(S)</span>
-                                        found for
-                                        <span data-v-2ef1c3d0="" class="blue">"libraries"</span>
-                                    </h3><!---->
-                                        <div data-v-2ef1c3d0=""
-                                             style="display: flex; margin-left: -30px;">
-                                            <div class=""
-                                                 style="box-sizing: border-box; background-clip: padding-box; width: 50%; border-width: 0px 0px 0px 30px; border-style: solid; border-color: transparent; border-image: initial;">
-                                                <article data-v-10f700a6=""
-                                                         data-v-2ef1c3d0=""
-                                                         aria-label="NYU Libraries Card"
-                                                         tabindex="0"
-                                                         class="card-contain">
-                                                    <div data-v-10f700a6=""
-                                                         class="flipper">
-                                                        <div data-v-10f700a6=""
-                                                             class="front">
-                                                            <div data-v-86d4ed2e=""
-                                                                 data-v-10f700a6="">
-                                                                <!---->
-                                                                <!----></div>
-                                                            <h2 data-v-10f700a6=""
-                                                                class="title">
-                                                                NYU
-                                                                Libraries</h2>
-                                                            <div data-v-10f700a6=""
-                                                                 class="front-content">
-                                                                <div class="bobcat_embed">
-                                                                    <div class="bobcat_embed_tabs_wrapper">
-                                                                        <div class="bobcat_embed_tabs">
-                                                                            <ul role="tablist">
-                                                                                <li role="tab"
-                                                                                    class="bobcat_embed_tabs_selected bobcat_embed_tabs_first">
-                                                                                    <a href="https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU"
-                                                                                       title="Search NYU's catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings"
-                                                                                       target="_blank">Catalog
-                                                                                        Search</a>
-                                                                                </li>
-                                                                                <li role="tab"
-                                                                                    class="bobcat_embed_tabs_inside">
-                                                                                    <a href="http://guides.nyu.edu/arch"
-                                                                                       title="Search databases for articles or browse databases by subject"
-                                                                                       target="_blank">Articles
-                                                                                        &amp;
-                                                                                        Databases</a>
-                                                                                </li>
-                                                                                <li role="tab"
-                                                                                    class="bobcat_embed_tabs_last">
-                                                                                    <a href="https://ares.library.nyu.edu/"
-                                                                                       title="Search for library materials that are held at one location for a particular course"
-                                                                                       target="_blank">Course
-                                                                                        Reserves</a>
-                                                                                </li>
-                                                                            </ul>
-                                                                        </div>
-                                                                    </div>
-                                                                    <div class="bobcat_embed_searchbox">
-                                                                        <div class="bobcat_embed_tab_content">
-                                                                            <form class="tab-1-search-form">
-                                                                                <div class="bobcat_embed_search_field">
-                                                                                    <span class="bobcat_embed_"><label
-                                                                                            for="tab-1-query">Search for</label> <input
-                                                                                            aria-label="Search Bobcat"
-                                                                                            type="text"
-                                                                                            id="tab-1-query"
-                                                                                            class="bobcat_embed_searchbox_textfield"></span>
-                                                                                    <span class="bobat_embed_searchbox_submit_container"><input
-                                                                                            aria-label="Search"
-                                                                                            name="Submit"
-                                                                                            type="submit"
-                                                                                            value="GO"
-                                                                                            class="bobcat_embed_searchbox_submit"></span>
-                                                                                </div>
-                                                                            </form>
-                                                                            <div class="bobcat_embed_links">
-                                                                                <ul>
-                                                                                    <li>
-                                                                                        <a href="https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&amp;mode=advanced"
-                                                                                           target="_blank">Advanced
-                                                                                            search</a>
-                                                                                    </li>
-                                                                                    <li>
-                                                                                        <a href="https://search.library.nyu.edu/discovery/citationlinker?vid=01NYU_INST:NYU"
-                                                                                           target="_blank">For
-                                                                                            full
-                                                                                            text
-                                                                                            articles
-                                                                                            use
-                                                                                            the
-                                                                                            search
-                                                                                            by
-                                                                                            citation
-                                                                                            tool</a>
-                                                                                    </li>
-                                                                                    <li>
-                                                                                        <a href="https://search.library.nyu.edu/discovery/account?vid=01NYU_INST:NYU&amp;section=overview"
-                                                                                           target="_blank"
-                                                                                           class="external-link">My
-                                                                                            Library
-                                                                                            Account</a>
-                                                                                    </li>
-                                                                                </ul>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </div><!----><!---->
-                                                            <div data-v-10f700a6=""
-                                                                 class="buttons">
-                                                                <!----><!---->
-                                                                <!---->
-                                                                <div data-v-1c65b77e=""
-                                                                     data-v-10f700a6=""
-                                                                     tabindex="-1"
-                                                                     class="settings-container"
-                                                                     aria-label="Flip NYU Libraries Card">
-                                                                    <svg data-v-1c65b77e=""
-                                                                         tabindex="0"
-                                                                         viewBox="-4 5 45 25.3"
-                                                                         width="45"
-                                                                         height="25.3"
-                                                                         id="src--main--webapp--images--raw-svgs--nyu_btn-settings"
-                                                                         y="525"
-                                                                         version="1.1"
-                                                                         role="button"
-                                                                         class="settings">
-                                                                        <g data-v-1c65b77e=""
-                                                                           fill="#559ACD"
-                                                                           id="g4780">
-                                                                            <path data-v-1c65b77e=""
-                                                                                  d="M6 17.6C6 16.2 7.2 15 8.6 15c1.5 0 2.6 1.2 2.6 2.6 0 1.5-1.2 2.6-2.6 2.6-1.4.1-2.6-1.1-2.6-2.6zM15.9 17.6c0-1.5 1.2-2.6 2.6-2.6s2.6 1.2 2.6 2.6c0 1.5-1.2 2.6-2.6 2.6s-2.6-1.1-2.6-2.6zM25.7 17.6c0-1.5 1.2-2.6 2.6-2.6s2.6 1.2 2.6 2.6c0 1.5-1.2 2.6-2.6 2.6s-2.6-1.1-2.6-2.6z"
-                                                                                  id="path4778"></path>
-                                                                        </g>
-                                                                    </svg>
-                                                                </div>
-                                                            </div>
-                                                            <div data-v-be603e76=""
-                                                                 data-v-10f700a6=""
-                                                                 aria-label="Collapse NYU Libraries Card">
-                                                                <svg data-v-be603e76=""
-                                                                     tabindex="0"
-                                                                     viewBox="3 91 32 22"
-                                                                     width="32"
-                                                                     height="22"
-                                                                     aria-label="Dismiss"
-                                                                     id="src--main--webapp--images--raw-svgs--nyu_btn-collapse"
-                                                                     role="button"
-                                                                     version="1.1"
-                                                                     class="dismiss">
-                                                                    <title data-v-be603e76="">
-                                                                        Dismiss</title>
-                                                                    <path data-v-be603e76=""
-                                                                          fill="none"
-                                                                          stroke="#559ACD"
-                                                                          stroke-width="2"
-                                                                          d="M13 102h12"
-                                                                          id="path4690"></path>
-                                                                </svg>
-                                                            </div>
-                                                            <button data-v-062afdab=""
-                                                                    data-v-10f700a6=""
-                                                                    id="nyu_btn-favorite"
-                                                                    tabindex="0"
-                                                                    class="favorite"
-                                                                    aria-label="Favorite NYU Libraries Card">
-                                                                <svg data-v-062afdab=""
-                                                                     viewBox="-2 134 41 54.5"
-                                                                     width="41"
-                                                                     height="54.5"
-                                                                     y="108"
-                                                                     version="1.1"
-                                                                     aria-hidden="true"
-                                                                     class="">
-                                                                    <title data-v-062afdab="">
-                                                                        Favorite</title>
-                                                                    <path data-v-062afdab=""
-                                                                          fill="none"
-                                                                          stroke="#559ACD"
-                                                                          d="M9.6 144.5c-.4 0-1.1-.2-1.1.2v32.5c0 .6.6.7 1 .4l9.3-8.8 9.3 9c.2.3.5.2.5-.2v-32.9c0-.4.1-.2-.2-.2H9.6z"
-                                                                          id="path4706"></path>
-                                                                </svg>
-                                                            </button>
-                                                        </div><!----></div>
-                                                </article>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div><!----></div>
-                    </div>
-                </div><!----></div>
-        </div>
-    </div><!----><!----><!----><!----></div>
-<script src="/js/chunk-vendors.39dbf672.js"></script>
-<script src="/js/app.0aa7cc41.js"></script>
+<!DOCTYPE html>
+<html lang=en>
+    <head>
+        <script>
+            (function(w, d, s, l, i) {
+                w[l] = w[l] || [];
+                w[l].push({
+                    "gtm.start": new Date().getTime(),
+                    event: "gtm.js"
+                });
+                var f = d.getElementsByTagName(s)[0]
+                  , j = d.createElement(s)
+                  , dl = l != "dataLayer" ? "&l=" + l : "";
+                j.async = true;
+                j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+                f.parentNode.insertBefore(j, f);
+            }
+            )(window, document, "script", "dataLayer", "GTM-KQB54DT");
+        </script>
+        <meta charset=utf-8>
+        <meta http-equiv=X-UA-Compatible content="IE=edge">
+        <meta name=viewport content="width=device-width,initial-scale=1">
+        <link rel=icon atype=image/x-icon href=/img/icons/favicon.png>
+        <title>[LOCAL OVERRIDE] NYU Home</title>
+        <link href=/css/chunk-14c7c3d2.8ab9cc59.css rel=prefetch>
+        <link href=/css/chunk-1b8610b0.60cb00ee.css rel=prefetch>
+        <link href=/css/chunk-2664ac6e.f8043fd4.css rel=prefetch>
+        <link href=/css/chunk-27d4e252.7190c220.css rel=prefetch>
+        <link href=/css/chunk-30b6a859.199073aa.css rel=prefetch>
+        <link href=/css/chunk-3511a9b1.4290d214.css rel=prefetch>
+        <link href=/css/chunk-4165a38f.abf40978.css rel=prefetch>
+        <link href=/css/chunk-4f1d4992.cb2337a8.css rel=prefetch>
+        <link href=/css/chunk-557bd6d4.642c5549.css rel=prefetch>
+        <link href=/css/chunk-5d01dde2.5ba01fad.css rel=prefetch>
+        <link href=/css/chunk-712a5866.7fc3ef64.css rel=prefetch>
+        <link href=/css/chunk-71e07923.d70331af.css rel=prefetch>
+        <link href=/css/chunk-75a09bb0.baad4a65.css rel=prefetch>
+        <link href=/css/chunk-87120890.b01a8de9.css rel=prefetch>
+        <link href=/css/chunk-95d628be.737bb96a.css rel=prefetch>
+        <link href=/css/chunk-9beb8a10.94f9219b.css rel=prefetch>
+        <link href=/css/chunk-a25f5f94.598309db.css rel=prefetch>
+        <link href=/css/chunk-a343a752.df0c128f.css rel=prefetch>
+        <link href=/css/chunk-d1354d08.177f5c6f.css rel=prefetch>
+        <link href=/css/chunk-da0d8a4c.23f5805a.css rel=prefetch>
+        <link href=/css/chunk-f0b7e896.4dbbd892.css rel=prefetch>
+        <link href=/css/common.390cd491.css rel=prefetch>
+        <link href=/js/chunk-14c7c3d2.0ff642ce.js rel=prefetch>
+        <link href=/js/chunk-1b8610b0.349923ea.js rel=prefetch>
+        <link href=/js/chunk-2664ac6e.29e0ee2c.js rel=prefetch>
+        <link href=/js/chunk-27d4e252.1551654d.js rel=prefetch>
+        <link href=/js/chunk-2d0daf2f.ebf1ccda.js rel=prefetch>
+        <link href=/js/chunk-30b6a859.c36a3715.js rel=prefetch>
+        <link href=/js/chunk-3511a9b1.f3ef13fd.js rel=prefetch>
+        <link href=/js/chunk-4165a38f.089c1895.js rel=prefetch>
+        <link href=/js/chunk-4f1d4992.eda32516.js rel=prefetch>
+        <link href=/js/chunk-557bd6d4.17146a8e.js rel=prefetch>
+        <link href=/js/chunk-5d01dde2.f40f172a.js rel=prefetch>
+        <link href=/js/chunk-712a5866.cf180191.js rel=prefetch>
+        <link href=/js/chunk-71e07923.ffa51d2e.js rel=prefetch>
+        <link href=/js/chunk-75a09bb0.e76b6225.js rel=prefetch>
+        <link href=/js/chunk-87120890.4e0fae91.js rel=prefetch>
+        <link href=/js/chunk-95d628be.1f231702.js rel=prefetch>
+        <link href=/js/chunk-9beb8a10.dbc23858.js rel=prefetch>
+        <link href=/js/chunk-a25f5f94.d6e3d69f.js rel=prefetch>
+        <link href=/js/chunk-a343a752.8b32a484.js rel=prefetch>
+        <link href=/js/chunk-d1354d08.4d5429e2.js rel=prefetch>
+        <link href=/js/chunk-da0d8a4c.25e73775.js rel=prefetch>
+        <link href=/js/chunk-f0b7e896.f8915de0.js rel=prefetch>
+        <link href=/js/common.e49d1874.js rel=prefetch>
+        <link href=/css/app.911e0180.css rel=preload as=style>
+        <link href=/js/app.99802315.js rel=preload as=script>
+        <link href=/js/chunk-vendors.39dbf672.js rel=preload as=script>
+        <link href=/css/app.911e0180.css rel=stylesheet>
+    </head>
+    <body>
+        <noscript>
+            <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQB54DT" height=0 width=0 style=display:none;visibility:hidden></iframe>
+        </noscript>
+        <noscript>
+            <strong>We're sorry but nyu doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+        </noscript>
+        <div id=app></div>
+        <script src=/js/chunk-vendors.39dbf672.js></script>
+        <script src=/js/app.99802315.js></script>
+    </body>
 </html>

--- a/config/institutions/nyuad.js
+++ b/config/institutions/nyuad.js
@@ -5,7 +5,7 @@ const vid = shared.isDeployEnvProd() ? '01NYU_AD:AD' : '01NYU_AD:AD_DEV';
 const abuDhabiPrimoEngine = {
     type       : 'primo',
     institution: 'NYUAD',
-    primoUrl  : 'https://search.abudhabi.library.nyu.edu',
+    primoUrl   : 'https://search.abudhabi.library.nyu.edu',
     vid        : vid,
     tab        : 'default_slot',
 };

--- a/config/institutions/nyuad.js
+++ b/config/institutions/nyuad.js
@@ -5,7 +5,7 @@ const vid = shared.isDeployEnvProd() ? '01NYU_AD:AD' : '01NYU_AD:AD_DEV';
 const abuDhabiPrimoEngine = {
     type       : 'primo',
     institution: 'NYUAD',
-    bobcatUrl  : 'https://search.abudhabi.library.nyu.edu',
+    primoUrl  : 'https://search.abudhabi.library.nyu.edu',
     vid        : vid,
     tab        : 'default_slot',
 };

--- a/config/institutions/nyush.js
+++ b/config/institutions/nyush.js
@@ -5,7 +5,7 @@ const vid = shared.isDeployEnvProd() ? '01NYU_US:SH' : '01NYU_US:SH_DEV';
 const shanghaiPrimoEngine = {
     type       : 'primo',
     institution: 'NYUSH',
-    bobcatUrl  : 'https://search.shanghai.library.nyu.edu',
+    primoUrl  : 'https://search.shanghai.library.nyu.edu',
     vid        : vid,
     scope      : 'CI_NYUSH',
     tab        : 'default_slot',

--- a/config/institutions/nyush.js
+++ b/config/institutions/nyush.js
@@ -5,7 +5,7 @@ const vid = shared.isDeployEnvProd() ? '01NYU_US:SH' : '01NYU_US:SH_DEV';
 const shanghaiPrimoEngine = {
     type       : 'primo',
     institution: 'NYUSH',
-    primoUrl  : 'https://search.shanghai.library.nyu.edu',
+    primoUrl   : 'https://search.shanghai.library.nyu.edu',
     vid        : vid,
     scope      : 'CI_NYUSH',
     tab        : 'default_slot',

--- a/config/shared.js
+++ b/config/shared.js
@@ -46,7 +46,7 @@ export default {
         nyuPrimoEngine: {
             type        : 'primo',
             institution : 'NYU',
-            primoUrl   : 'https://search.library.nyu.edu',
+            primoUrl    : 'https://search.library.nyu.edu',
             vid         : vid,
             defaultScope: 'CI_NYU_CONSORTIA',
             scopesMap   : {

--- a/config/shared.js
+++ b/config/shared.js
@@ -46,7 +46,7 @@ export default {
         nyuPrimoEngine: {
             type        : 'primo',
             institution : 'NYU',
-            bobcatUrl   : 'https://search.library.nyu.edu',
+            primoUrl   : 'https://search.library.nyu.edu',
             vid         : vid,
             defaultScope: 'CI_NYU_CONSORTIA',
             scopesMap   : {

--- a/src/test/utils/searchRedirects.spec.js
+++ b/src/test/utils/searchRedirects.spec.js
@@ -12,11 +12,17 @@ describe( 'primoSearch', () => {
     };
 
     it( 'should return an appropriately composed search url', () => {
-        expect( primoSearch( params ) ).toEqual( 'http://bobcat.university.edu/discovery/search?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US' );
+        expect( primoSearch( params ) )
+            .toEqual(
+                'http://bobcat.university.edu/discovery/search?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US'
+            );
     } );
 
     it( 'can modify the search method', () => {
-        expect( primoSearch( { searchMethod: 'jsearch', ...params } ) ).toEqual( 'http://bobcat.university.edu/discovery/jsearch?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US' )
+        expect( primoSearch( { searchMethod: 'jsearch', ...params } ) )
+            .toEqual(
+                'http://bobcat.university.edu/discovery/jsearch?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US'
+            );
     } );
 } );
 

--- a/src/test/utils/searchRedirects.spec.js
+++ b/src/test/utils/searchRedirects.spec.js
@@ -26,23 +26,23 @@ describe( 'primoSearch', () => {
     it( 'returns the correct search URL for a non-empty search', () => {
         const params = {
             ...commonParams,
-            search : 'monk and music', // "monk%20and%20music"
+            search: 'monk and music', // "monk%20and%20music"
         };
         expect( primoSearch( params ) )
             .toEqual(
-                'http://bobcat.university.edu/discovery/search?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US'
+                'http://bobcat.university.edu/discovery/search?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US',
             );
     } );
 
     it( 'can modify the search method', () => {
         const params = {
             ...commonParams,
-            search : 'monk and music', // "monk%20and%20music"
+            search      : 'monk and music', // "monk%20and%20music"
             searchMethod: 'jsearch',
         };
         expect( primoSearch( params ) )
             .toEqual(
-                'http://bobcat.university.edu/discovery/jsearch?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US'
+                'http://bobcat.university.edu/discovery/jsearch?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US',
             );
     } );
 } );
@@ -50,7 +50,10 @@ describe( 'primoSearch', () => {
 describe( 'guidesSearch', () => {
     it( 'should return an appropriately composed search url', () => {
         expect(
-            guidesSearch( { search: 'this is a search', guidesUrl: 'http://guides.university.edu' } ), //'this%20is%20a%20search'
+            guidesSearch( {
+                search   : 'this is a search',
+                guidesUrl: 'http://guides.university.edu',
+            } ), //'this%20is%20a%20search'
         ).toEqual( 'http://guides.university.edu/srch.php?&q=this%20is%20a%20search' );
     } );
 } );

--- a/src/test/utils/searchRedirects.spec.js
+++ b/src/test/utils/searchRedirects.spec.js
@@ -2,16 +2,32 @@ import { describe, expect, it } from 'vitest';
 import { primoSearch, guidesSearch } from '../../utils/searchRedirects';
 
 describe( 'primoSearch', () => {
-    const params = {
+    const commonParams = {
         tab        : 'all',
         scope      : 'uniscope',
         primoUrl   : 'http://bobcat.university.edu',
-        search     : 'monk and music', // "monk%20and%20music"
         institution: 'UNI',
         vid        : 'UNI-NUI',
     };
 
-    it( 'should return an appropriately composed search url', () => {
+    const expectedEmptySearchURL =
+        'http://bobcat.university.edu/discovery/search?vid=UNI-NUI&search_scope=uniscope';
+
+    it( 'returns the correct URL for empty search ""', () => {
+        const params = { ...commonParams, search: '' };
+        expect( primoSearch( params ) ).toEqual( expectedEmptySearchURL );
+    } );
+
+    it( 'returns the correct URL for an all whitespace search', () => {
+        const params = { ...commonParams, search: '       ' };
+        expect( primoSearch( params ) ).toEqual( expectedEmptySearchURL );
+    } );
+
+    it( 'returns the correct search URL for a non-empty search', () => {
+        const params = {
+            ...commonParams,
+            search : 'monk and music', // "monk%20and%20music"
+        };
         expect( primoSearch( params ) )
             .toEqual(
                 'http://bobcat.university.edu/discovery/search?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US'
@@ -19,7 +35,12 @@ describe( 'primoSearch', () => {
     } );
 
     it( 'can modify the search method', () => {
-        expect( primoSearch( { searchMethod: 'jsearch', ...params } ) )
+        const params = {
+            ...commonParams,
+            search : 'monk and music', // "monk%20and%20music"
+            searchMethod: 'jsearch',
+        };
+        expect( primoSearch( params ) )
             .toEqual(
                 'http://bobcat.university.edu/discovery/jsearch?institution=UNI&vid=UNI-NUI&tab=all&search_scope=uniscope&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=monk%20and%20music&query=any,contains,monk%20and%20music&sortby=rank&lang=en_US'
             );

--- a/src/test/utils/searchRedirects.spec.js
+++ b/src/test/utils/searchRedirects.spec.js
@@ -5,7 +5,7 @@ describe( 'primoSearch', () => {
     const params = {
         tab        : 'all',
         scope      : 'uniscope',
-        bobcatUrl  : 'http://bobcat.university.edu',
+        primoUrl   : 'http://bobcat.university.edu',
         search     : 'monk and music', // "monk%20and%20music"
         institution: 'UNI',
         vid        : 'UNI-NUI',

--- a/src/utils/searchRedirects.js
+++ b/src/utils/searchRedirects.js
@@ -95,8 +95,11 @@ export const primoSearch = ( { tab, scope, primoUrl, search, institution, vid, s
             { sort: qsSortBy( qsOrder ), encode: false },
         );
     } else {
-        // Redirect to Primo home page with preset search scope dropdown.
-        qsParams = `vid=${ vid }&search_scope=${ scope }`;
+        // Redirect to Primo home page with optional preset search scope dropdown.
+        qsParams = `vid=${ vid }`;
+        if ( scope ) {
+            qsParams += `&search_scope=${ scope }`;
+        }
     }
 
     return `${ primoUrl }/discovery/${ searchMethod }?${ qsParams }`;

--- a/src/utils/searchRedirects.js
+++ b/src/utils/searchRedirects.js
@@ -43,12 +43,12 @@ export const getitSearch = ( { institution, issn, title, type, getitUrl } ) => {
     }
 };
 
-export const primoSearch = ( { tab, scope, bobcatUrl, search, institution, vid, searchMethod = 'search' } ) => {
+export const primoSearch = ( { tab, scope, primoUrl, search, institution, vid, searchMethod = 'search' } ) => {
     let qsParams;
 
-    // Redirect to BobCat search if `search` is non-empty.
-    // If `search` is empty of meaningful user input, redirect to the BobCat home
-    // page instead of redirecting to a BobCat blank search, which returns error messages
+    // Redirect to the Primo landing page if `search` is non-empty.
+    // If `search` is empty of meaningful user input, redirect to the Primo home
+    // page instead of redirecting to a blank search, which returns error messages
     // that are potentially confusing.
     //
     // For details, see:
@@ -115,7 +115,7 @@ export const primoSearch = ( { tab, scope, bobcatUrl, search, institution, vid, 
         );
     }
 
-    return `${ bobcatUrl }/discovery/${ searchMethod }?${ qsParams }`;
+    return `${ primoUrl }/discovery/${ searchMethod }?${ qsParams }`;
 };
 
 export const guidesSearch = ( { search, guidesUrl } ) => {

--- a/src/utils/searchRedirects.js
+++ b/src/utils/searchRedirects.js
@@ -95,24 +95,8 @@ export const primoSearch = ( { tab, scope, primoUrl, search, institution, vid, s
             { sort: qsSortBy( qsOrder ), encode: false },
         );
     } else {
-        // Include scope in the query string even when search is empty
-        qsParams = queryStringify(
-            {
-                institution,
-                vid,
-                tab,
-                search_scope: scope,
-            },
-            {
-                sort: qsSortBy( [ 
-                    'institution',
-                    'vid',
-                    'tab',
-                    'search_scope', 
-                ] ),
-                encode: false, 
-            },
-        );
+        // Redirect to Primo home page with preset search scope dropdown.
+        qsParams = `vid=${ vid }&search_scope=${ scope }`;
     }
 
     return `${ primoUrl }/discovery/${ searchMethod }?${ qsParams }`;


### PR DESCRIPTION
* Simplify handling of Primo empty searches in `searchRedirects.js`
  * Remove `institution` and `tag` query params from `primoSearch` returned URL
  * Only include `search_scope` in `primoSearch` URL if `scope` it truthy.  For https://guides.nyu.edu/nyushcscapstone/books it will not be defined as there is no search scope dropdown for that `bess-vue` instance.
* Add tests for empty and all-whitespace Primo searches
* Replace obsolete "bobcatUrl" with "primoUrl"
* Update browser override HTML and JS files for https://globalhome.nyu.edu/services/search/libraries
