### PR TITLE
SearchRedirectForm.vue: use search scope from `engine` config if no `ui` dropdown config

### DIFF
--- a/src/components/searchForms/SearchRedirectForm.vue
+++ b/src/components/searchForms/SearchRedirectForm.vue
@@ -60,7 +60,7 @@ export default {
     data() {
         return {
             search             : '',
-            selectedSearchScope: this.ui.searchScopeDropdown?.defaultOption,
+            selectedSearchScope: this.ui.searchScopeDropdown?.defaultOption || this.searchEngineProps.scope,
         };
     },
     computed: {


### PR DESCRIPTION
Fixes bug introduced by this change: [SearchForm\.vue: Update inital prop value after renaming scope in shared\.js](https://github.com/NYULibraries/bess-vue/commit/a6325b43fec3cd9c4b54d20747abc8da3567be54), which was made in conjunction with this update: [config/shared\.js: Rename scope key to defaultScope in nyuPrimoEngine](https://github.com/NYULibraries/bess-vue/commit/f62b3fc6432134222c2d38b648b855184fe4abf8).
The `scope` property is being used in _[bess\-vue/config/institutions /nyuad\.js](https://github.com/NYULibraries/bess-vue/blob/master/config/institutions/nyuad.js)_ and _[bess\-vue/config/institutions /nyush\.js](https://github.com/NYULibraries/bess-vue/blob/master/config/institutions/nyush.js)_ as well, so we need to check for both UI default option for search scope and default search scopes defined in the config files.