### PR TITLE
Fix NYUAD "Course Reserves" tab search scope

### DIFF
--- a/config/institutions/nyuad.js
+++ b/config/institutions/nyuad.js
@@ -37,7 +37,7 @@ export default [
         title : shared.tabs.aresReserves.title,
         engine: {
             ...abuDhabiPrimoEngine,
-            scope: 'CI_NYUAD_NYU',
+            scope: 'CourseReserves',
         },
         more: [
             `<a href="https://search.abudhabi.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,

--- a/src/components/searchForms/SearchRedirectForm.vue
+++ b/src/components/searchForms/SearchRedirectForm.vue
@@ -75,6 +75,14 @@ export default {
             };
         },
     },
+    watch: {
+        // Get new search scope when user changes tabs.
+        searchEngineProps( newValue ) {
+            if ( newValue.scope ) {
+                this.selectedSearchScope = newValue.scope;
+            }
+        },
+    },
     methods: {
         openSearch() {
             window.open( this.searchFunction( this.searchValues ) );


### PR DESCRIPTION
* Fix incorrect `scope` value for NYUAD "Course Reserves" introduced in the major overhaul PR [Upgrade Vue and toolchain \#94](https://github.com/NYULibraries/bess-vue/pull/94).
* Add `watch` of `searchEngineProps` to `SearchRedirectForm` so that `this.selectedTab` will update when user changes tabs (which updates non-reactive component prop `searchEngineProps`).