### PR TITLE
Temporarily remove the form input placeholder text for NYU [+]

### DIFF
--- a/config/institutions/nyu.js
+++ b/config/institutions/nyu.js
@@ -2,6 +2,8 @@ import shared from '../shared.js';
 
 const vid = shared.isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
 
+// For details on why we are using empty strings for all `placeholder` values,
+// see https://nyu-lib.monday.com/boards/765008773/pulses/7296310519.
 export default [
     {
         ...shared.tabs.catalogSearch,
@@ -20,19 +22,19 @@ export default [
                 options      : {
                     CI_NYU_CONSORTIA: {
                         label      : 'Library catalog',
-                        placeholder: '"disability in higher education", Journal of Medicine, JSTOR',
+                        placeholder: '',
                     },
                     NYU_CONSORTIA: {
                         label      : 'Library catalog (excluding articles)',
-                        placeholder: 'Hamlet, Journal of Medicine, JSTOR',
+                        placeholder: '',
                     },
                     ARTICLES: {
                         label      : 'Articles',
-                        placeholder: 'race AND media, film OR movie',
+                        placeholder: '',
                     },
                     NYUBAFC: {
                         label      : 'NYU Avery Fisher Center (A/V materials)',
-                        placeholder: 'Moonlight',
+                        placeholder: '',
                     },
                     NYUSC: {
                         label      : 'NYU Special Collections',

--- a/src/test/App.vue/__snapshots__/App.vue.spec.js.snap
+++ b/src/test/App.vue/__snapshots__/App.vue.spec.js.snap
@@ -15,7 +15,7 @@ exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > has the correct HTML 1`] = `
   <div class="bobcat_embed_searchbox">
     <div class="bobcat_embed_tab_content">
       <form class="tab-1-search-form">
-        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield" placeholder="&quot;disability in higher education&quot;, Journal of Medicine, JSTOR" aria-describedby="&quot;disability in higher education&quot;, Journal of Medicine, JSTOR"></span><select id="tab-1-scope" class="bobcat_embed_select_value" aria-label="Select search scope">
+        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield" placeholder="" aria-describedby=""></span><select id="tab-1-scope" class="bobcat_embed_select_value" aria-label="Select search scope">
             <option value="CI_NYU_CONSORTIA">Library catalog</option>
             <option value="NYU_CONSORTIA">Library catalog (excluding articles)</option>
             <option value="ARTICLES">Articles</option>
@@ -141,7 +141,7 @@ exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > has the correct HTML 1`] =
   <div class="bobcat_embed_searchbox">
     <div class="bobcat_embed_tab_content">
       <form class="tab-1-search-form">
-        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield" placeholder="&quot;disability in higher education&quot;, Journal of Medicine, JSTOR" aria-describedby="&quot;disability in higher education&quot;, Journal of Medicine, JSTOR"></span><!-- Dropdown for selecting search scope --><select id="tab-1-scope" class="bobcat_embed_select_value" aria-label="Select search scope">
+        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield" placeholder="" aria-describedby=""></span><!-- Dropdown for selecting search scope --><select id="tab-1-scope" class="bobcat_embed_select_value" aria-label="Select search scope">
             <option value="CI_NYU_CONSORTIA">Library catalog</option>
             <option value="NYU_CONSORTIA">Library catalog (excluding articles)</option>
             <option value="ARTICLES">Articles</option>


### PR DESCRIPTION
See https://nyu-lib.monday.com/boards/765008773/pulses/7296310519.

Remove `placeholder` attribute text but leave the placeholder feature in place for possible future use.