### PR TITLE
config/institutions/nyu-home.js: restore hardcoded scope [+]

### DIFF
--- a/config/institutions/nyu-home.js
+++ b/config/institutions/nyu-home.js
@@ -9,8 +9,11 @@ export default [
             'href'  : `https://search.library.nyu.edu/discovery/search?vid=${ vid }`,
             'target': '_blank',
         },
-        engine: shared.engines.nyuPrimoEngine,
-        more  : [
+        engine: {
+            ...shared.engines.nyuPrimoEngine,
+            scope: 'CI_NYU_CONSORTIA',
+        },
+        more: [
             `<a href="https://search.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
             `<a href="https://search.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">For full text articles use the search by citation tool</a>`,
             `<a href="https://search.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank" class="external-link">My Library Account</a>`,


### PR DESCRIPTION
`scope` was renamed `defaultScope` in https://github.com/NYULibraries/bess-vue/commit/f62b3fc6432134222c2d38b648b855184fe4abf8 (and `defaultScope` itself was moved to `nyu.js` later).  The redirect code drops the `scope` query param from the query string used for the `window.open` target URL because it's not defined.  Primo VE appears to default to the scope we want if `scope` query param is missing.  Adding it back for consistency with earlier version, and so we have finer control over the scope.