### PR TITLE
Restore vitest snapshots for `VITE_DEPLOY_ENV=prod` and delete `update-snapshots` npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ docker compose up test
 
 * `vite` injects a `<style>` tag into the HTML containing the compiled CSS from
 the Vue SFCs, which causes no problems when developing locally w/ HMR or viewing 
-the viewing the embedded widgets in _index-all-institutions.html_, but when
-embedding the widget in a web page that does not opt to use the styles from the
-project, this injected `<style>` tag can override the intended styles from that
-web page's stylesheets and `<style>` tags.
+the embedded widgets in _index-all-institutions.html_, but when  embedding the 
+widget in a web page that does not opt to use the styles from the project, this
+injected `<style>` tag can override the intended styles from that web page's
+stylesheets and `<style>` tags.
 * This injection happens in both `development` and `production` mode.
 `rollupOptions.output.assetFileNames` in _vite.config.js_ ensures the creation
 of the CSS file in _dist/_, but does not suppress the injection of the `<style>`

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ docker compose up test
 
 ## Caveats
 
+### Running `vitest --update` one time and commiting the snapshots changes will result in half of the snapshots being mistakenly deleted
+
+See the long file header comment in for _src/test/App.vue/App.vue.spec.js_ for
+details on why this happens and the way to work around this issue.  We will
+likely be able to fix this issue later, but for now, updating the vitest snapshots
+is a two-step manual process.
+
+### For now, do not add an `update-snapshots` npm script to _package.json_
+
+See caveat "Running `vitest --update` one time and commiting the snapshots changes will
+result in half of the snapshots being mistakenly deleted".
+
 ### Do not put `<style>` tags in SFCs
 
 * `vite` injects a `<style>` tag into the HTML containing the compiled CSS from

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "npm run test:unit && npm run test:unit:app:prod",
     "test:unit": "NODE_ENV=production vitest run",
     "test:unit:app:prod": "NODE_ENV=production VITE_DEPLOY_ENV=prod vitest run --mode=production src/test/App.vue/App.vue.spec.js",
-    "update-snapshots": "NODE_ENV=production vitest run --update",
     "update-browser-overrides": "npm run build:prod && scripts/update-browser-overrides-app-builds.sh",
     "eslint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore",
     "eslint:fix": "npm run eslint -- --fix"

--- a/src/test/App.vue/App.vue.spec.js
+++ b/src/test/App.vue/App.vue.spec.js
@@ -10,7 +10,7 @@
 // the config module, so subsequent attempts to change `import.meta.env.VITE_DEPLOY_ENV`
 // in the configuration after initial import all fail.  We work around this
 // problem by doing separate runs of this test file for VITE_DEPLOY_ENV=prod and
-// VITE_DEPLOY_PROD_ENV left undefined, which is the value of the environment
+// VITE_DEPLOY_ENV left undefined, which is the value of the environment
 // variable when in test mode.
 //
 // Note that a different set of snapshots is produced/checked for each

--- a/src/test/App.vue/App.vue.spec.js
+++ b/src/test/App.vue/App.vue.spec.js
@@ -40,6 +40,19 @@
 //                · App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search > should call `window.open` with correct URL > for non-empty search 1
 //                · App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > has the correct HTML 1
 //
+// Note that we do not currently have an `update-snapshots` npm script because
+// vitest automatically deletes any snapshots it determines are obsolete, and
+// currently this results in the aforementioned snapshots that are not truly
+// obsolete but only circumstantially obsolete for a single test run
+// referenced above to be deleted when the `--update` flag is set.
+// For now, the only way to update snapshots is to run the test suite two
+// separate times for `VITE_DEPLOY_ENV=prod` and `VITE_DEPLOY_ENV` not defined.
+// After each run, use `git add --patch` to only commit the snapshot changes for
+// the `VITE_DEPLOY_ENV` group being tested, and to not commit the deletions of
+// the not-really-obsolete complementary group of snapshots that weren't used.
+//
+// Later we will figure out a way to make it possible to run the test suite
+// for both `VITE_DEPLOY_ENV` states in the same test run.
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { config, mount } from '@vue/test-utils';
 import App from '@/App.vue';

--- a/src/test/App.vue/__snapshots__/App.vue.spec.js.snap
+++ b/src/test/App.vue/__snapshots__/App.vue.spec.js.snap
@@ -1,5 +1,200 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=ARTICLES"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=ARTICLES"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=ARTICLES&query=any,contains,art"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYU_CONSORTIA&query=any,contains,art"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUBAFC"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUBAFC"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYUBAFC&query=any,contains,art"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUSC"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUSC"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYUSC&query=any,contains,art"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > has the correct HTML 1`] = `
+"<div class="bobcat_embed">
+  <div class="bobcat_embed_tabs_wrapper">
+    <div class="bobcat_embed_tabs">
+      <ul role="tablist">
+        <li class="bobcat_embed_tabs_selected bobcat_embed_tabs_first" role="tab"><a href="#" title="Search NYU's catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings">Catalog Search</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="http://guides.nyu.edu/arch" title="Search databases for articles or browse databases by subject" target="_blank">Databases</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="https://guides.nyu.edu" title="Guides to help you find library resources on specific subjects and courses" target="_blank">Research Guides</a></li>
+        <li class="bobcat_embed_tabs_last" role="tab"><a href="https://ares.library.nyu.edu/" title="Search for library materials that are held at one location for a particular course" target="_blank">Course Reserves</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="bobcat_embed_searchbox">
+    <div class="bobcat_embed_tab_content">
+      <form class="tab-1-search-form">
+        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield" placeholder="" aria-describedby=""></span><select id="tab-1-scope" class="bobcat_embed_select_value" aria-label="Select search scope">
+            <option value="CI_NYU_CONSORTIA">Library catalog</option>
+            <option value="NYU_CONSORTIA">Library catalog (excluding articles)</option>
+            <option value="ARTICLES">Articles</option>
+            <option value="NYUBAFC">NYU Avery Fisher Center (A/V materials)</option>
+            <option value="NYUSC">NYU Special Collections</option>
+          </select><span class="bobat_embed_searchbox_submit_container"><input aria-label="Search" class="bobcat_embed_searchbox_submit" name="Submit" type="submit" value="GO"></span></div>
+      </form>
+      <div class="bobcat_embed_links">
+        <ul>
+          <li><a href="https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&amp;lang=en&amp;mode=advanced" target="_blank">Advanced search</a></li>
+          <li>Need the full text of an article? <a href="https://search.library.nyu.edu/discovery/citationlinker?vid=01NYU_INST:NYU" target="_blank">Use the search by citation tool</a>.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > has the correct HTML 1`] = `
+"<div class="bobcat_embed">
+  <div class="bobcat_embed_tabs_wrapper">
+    <div class="bobcat_embed_tabs">
+      <ul role="tablist">
+        <li class="bobcat_embed_tabs_selected bobcat_embed_tabs_first" role="tab"><a href="https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU" title="Search NYU's catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings" target="_blank">Catalog Search</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="http://guides.nyu.edu/arch" title="Search databases for articles or browse databases by subject" target="_blank">Articles &amp; Databases</a></li>
+        <li class="bobcat_embed_tabs_last" role="tab"><a href="https://ares.library.nyu.edu/" title="Search for library materials that are held at one location for a particular course" target="_blank">Course Reserves</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="bobcat_embed_searchbox">
+    <div class="bobcat_embed_tab_content">
+      <form class="tab-1-search-form">
+        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield"></span>
+          <!----><span class="bobat_embed_searchbox_submit_container"><input aria-label="Search" class="bobcat_embed_searchbox_submit" name="Submit" type="submit" value="GO"></span>
+        </div>
+      </form>
+      <div class="bobcat_embed_links">
+        <ul>
+          <li><a href="https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&amp;mode=advanced" target="_blank">Advanced search</a></li>
+          <li><a href="https://search.library.nyu.edu/discovery/citationlinker?vid=01NYU_INST:NYU" target="_blank">For full text articles use the search by citation tool</a></li>
+          <li><a href="https://search.library.nyu.edu/discovery/account?vid=01NYU_INST:NYU&amp;section=overview" target="_blank" class="external-link">My Library Account</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'all-whitespace search': '    ' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&search_scope=CI_NYUAD_NYU"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'empty search': '' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&search_scope=CI_NYUAD_NYU"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'non-empty search': 'art' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?institution=NYUAD&vid=01NYU_AD:AD&tab=default_slot&search_scope=CI_NYUAD_NYU&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > has the correct HTML 1`] = `
+"<div class="bobcat_embed">
+  <div class="bobcat_embed_tabs_wrapper">
+    <div class="bobcat_embed_tabs">
+      <ul role="tablist">
+        <li class="bobcat_embed_tabs_selected bobcat_embed_tabs_first" role="tab"><a href="#" title="Search NYU's catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings">Catalog Search</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="http://guides.nyu.edu/adarch" title="Search databases for articles or browse databases by subject" target="_blank">Articles &amp; Databases</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="#" title="Search for library materials that are held at one location for a particular course">Course Reserves</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="#" title="Guides to help you find library resources on specific subjects and courses">Research Guides</a></li>
+        <li class="bobcat_embed_tabs_last" role="tab"><a href="#" title="My Accounts">My Accounts</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="bobcat_embed_searchbox">
+    <div class="bobcat_embed_tab_content">
+      <form class="tab-1-search-form">
+        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield"></span>
+          <!----><span class="bobat_embed_searchbox_submit_container"><input aria-label="Search" class="bobcat_embed_searchbox_submit" name="Submit" type="submit" value="GO"></span>
+        </div>
+      </form>
+      <div class="bobcat_embed_links">
+        <ul>
+          <li><a href="https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&amp;mode=advanced" target="_blank">Advanced search</a></li>
+          <li>Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=01NYU_AD:AD" target="_blank">Use the search by citation tool</a>.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_NYUSH_NYU_CONSORTIA&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_articles"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_articles"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_articles&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=NYUSH"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=NYUSH"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+
+exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > has the correct HTML 1`] = `
+"<div class="bobcat_embed">
+  <div class="bobcat_embed_tabs_wrapper">
+    <div class="bobcat_embed_tabs">
+      <ul role="tablist">
+        <li class="bobcat_embed_tabs_selected bobcat_embed_tabs_first" role="tab"><a href="#" title="Search NYU's catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings">Catalog Search</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="http://guides.nyu.edu/arch" title="Search databases for articles or browse databases by subject" target="_blank">Databases</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="https://ares.library.nyu.edu/" title="Search for library materials that are held at one location for a particular course" target="_blank">Course Reserves</a></li>
+        <li class="bobcat_embed_tabs_inside" role="tab"><a href="#" title="Guides to help you find library resources on specific subjects and courses">Research Guides</a></li>
+        <li class="bobcat_embed_tabs_last" role="tab"><a href="#" title="My Accounts">My Accounts</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="bobcat_embed_searchbox">
+    <div class="bobcat_embed_tab_content">
+      <form class="tab-1-search-form">
+        <div class="bobcat_embed_search_field"><span class="bobcat_embed_"><label for="tab-1-query">Search for </label><input id="tab-1-query" aria-label="Search Bobcat" type="text" class="bobcat_embed_searchbox_textfield" placeholder="" aria-describedby=""></span><select id="tab-1-scope" class="bobcat_embed_select_value" aria-label="Select search scope">
+            <option value="CI_NYUSH">All at Shanghai</option>
+            <option value="CI_NYUSH_NYU_CONSORTIA">All at NYU</option>
+            <option value="CI_articles">All Articles</option>
+            <option value="NYUSH">Classic Search</option>
+          </select><span class="bobat_embed_searchbox_submit_container"><input aria-label="Search" class="bobcat_embed_searchbox_submit" name="Submit" type="submit" value="GO"></span></div>
+      </form>
+      <div class="bobcat_embed_links">
+        <ul>
+          <li><a href="https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&amp;mode=advanced" target="_blank">Advanced search</a></li>
+          <li>Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=01NYU_US:SH" target="_blank">Use the search by citation tool</a>.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
 exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=ARTICLES"`;
 
 exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=ARTICLES"`;


### PR DESCRIPTION
* Restore the vitest snapshots for `VITE_DEPLOY_ENV=prod` that were accidentally deleted in [d4296aa42e80c03898898e5f926044dcc4c2c382](https://github.com/NYULibraries/bess-vue/commit/d4296aa42e80c03898898e5f926044dcc4c2c382).
* Delete the `update-snapshots` npm script that was added in that branch.  This is temporary.
* Added documentation to _README.md_ and the file header for _src/test/App.vue/App.vue.spec.js_ explaining why we have to hold off on making an `update-snapshots` script.