### PR TITLE
config/: change `ui.searchScopeDropdown.options` from an object to an array to enable control over option ordering in the dropdown

### DIFF
--- a/config/institutions/nyu.js
+++ b/config/institutions/nyu.js
@@ -19,28 +19,33 @@ export default [
             // xpath query as of 2024-08-15: /html/body/primo-explore/div/prm-explore-main/div/prm-search-bar/div[1]/div/div[2]/div/form/div/div/div[2]/prm-tabs-and-scopes-selector/div/md-input-container/md-select/div/md-select-menu/md-content/div[2]
             searchScopeDropdown: {
                 defaultOption: 'CI_NYU_CONSORTIA',
-                options      : {
-                    CI_NYU_CONSORTIA: {
+                options      : [
+                    {
                         label      : 'Library catalog',
                         placeholder: '',
+                        value      : 'CI_NYU_CONSORTIA',
                     },
-                    NYU_CONSORTIA: {
+                    {
                         label      : 'Library catalog (excluding articles)',
                         placeholder: '',
+                        value      : 'NYU_CONSORTIA',
                     },
-                    ARTICLES: {
+                    {
                         label      : 'Articles',
                         placeholder: '',
+                        value      : 'ARTICLES',
                     },
-                    NYUBAFC: {
+                    {
                         label      : 'NYU Avery Fisher Center (A/V materials)',
                         placeholder: '',
+                        value      : 'NYUBAFC',
                     },
-                    NYUSC: {
+                    {
+                        value      : 'NYUSC',
                         label      : 'NYU Special Collections',
                         placeholder: '',
                     },
-                },
+                ],
             },
         },
     },

--- a/config/institutions/nyush.js
+++ b/config/institutions/nyush.js
@@ -24,14 +24,16 @@ export default [
             // xpath query as of 2024-08-15: /html/body/primo-explore/div/prm-explore-main/div/prm-search-bar/div[1]/div/div[2]/div/form/div/div/div[2]/prm-tabs-and-scopes-selector/div/md-input-container/md-select/div/md-select-menu/md-content/div[2]
             searchScopeDropdown: {
                 defaultOption: 'CI_NYUSH',
-                options      : {
-                    CI_NYUSH: {
+                options      : [
+                    {
                         label      : 'All at Shanghai',
                         placeholder: '',
+                        value      : 'CI_NYUSH',
                     },
-                    CI_NYUSH_NYU_CONSORTIA: {
+                    {
                         label      : 'All at NYU',
                         placeholder: '',
+                        value      : 'CI_NYUSH_NYU_CONSORTIA',
                     },
                     // Do not change this to CI_ARTICLES.  The search scope query
                     // parameter is apparently case-sensitive.  Compare results:
@@ -42,15 +44,17 @@ export default [
                     // As of 2024-09-16, the CI_ARTICLES URL redirects to:
                     // https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&vid=01NYU_US:SH&offset=0
                     // ...`search_scope` query param is removed.
-                    CI_articles: {
+                    {
                         label      : 'All Articles',
                         placeholder: '',
+                        value      : 'CI_articles',
                     },
-                    NYUSH: {
+                    {
                         label      : 'Classic Search',
                         placeholder: '',
+                        value      : 'NYUSH',
                     },
-                },
+                ],
             },
         },
     },

--- a/src/components/searchForms/SearchRedirectForm.vue
+++ b/src/components/searchForms/SearchRedirectForm.vue
@@ -26,11 +26,11 @@
         aria-label="Select search scope"
       >
         <option
-          v-for="( config, searchScopeValue ) in ui.searchScopeDropdown.options"
-          :key="searchScopeValue"
-          :value="searchScopeValue"
+          v-for="( searchScopeOption ) in ui.searchScopeDropdown.options"
+          :key="searchScopeOption.value"
+          :value="searchScopeOption.value"
         >
-          {{ config.label }}
+          {{ searchScopeOption.label }}
         </option>
       </select>
 
@@ -82,7 +82,11 @@ export default {
     },
     computed: {
         placeholder() {
-            return this.ui.searchScopeDropdown?.options[ this.selectedSearchScope ].placeholder;
+            if ( !this.ui.searchScopeDropdown ) {
+                return undefined;
+            }
+
+            return this.option( this.selectedSearchScope )?.placeholder;
         },
         searchValues() {
             return {
@@ -103,6 +107,13 @@ export default {
     methods: {
         openSearch() {
             window.open( this.searchFunction( this.searchValues ) );
+        },
+        option() {
+            return this.ui.searchScopeDropdown.options.find(
+                option => {
+                    return option.value === this.selectedSearchScope;
+                },
+            );
         },
     },
 };

--- a/src/test/App.vue/App.vue.spec.js
+++ b/src/test/App.vue/App.vue.spec.js
@@ -105,7 +105,7 @@ describe( `App [ VITE_DEPLOY_ENV: ${ process.env.VITE_DEPLOY_ENV } ]`, () => {
             // undefined `appConfig.institutions[ institution ][ 0 ].ui`.
             let currentConfig = appConfig.institutions[ institution ];
             let searchScopeDropdownOptionValues = currentConfig[ 0 ].ui?.searchScopeDropdown.options ?
-                Object.keys( currentConfig[ 0 ].ui?.searchScopeDropdown.options ) :
+                currentConfig[ 0 ].ui?.searchScopeDropdown.options :
                 [];
 
             beforeEach( () => {
@@ -130,7 +130,7 @@ describe( `App [ VITE_DEPLOY_ENV: ${ process.env.VITE_DEPLOY_ENV } ]`, () => {
                 describe.each(
                     [
                         ...searchScopeDropdownOptionValues.map( function ( option ) {
-                            return { 'searchScopeDropdownValue': option }
+                            return { 'searchScopeDropdownValue': option.value }
                         } ),
                     ],
                 )(

--- a/src/test/components/searchForms/SearchRedirectForm.vue.spec.js
+++ b/src/test/components/searchForms/SearchRedirectForm.vue.spec.js
@@ -151,16 +151,16 @@ describe( 'SearchRedirectForm', () => {
             } );
 
             test( 'has placeholder text, if defined', () => {
-                const expectedPlaceholder = nyuProps.ui.searchScopeDropdown.options[
-                    nyuProps.ui.searchScopeDropdown.defaultOption
-                ].placeholder;
+                const expectedPlaceholder =
+                    wrapper.vm.option( nyuProps.ui.searchScopeDropdown.defaultOption )
+                        ?.placeholder;
                 expect( input.attributes( 'placeholder' ) ).toBe( expectedPlaceholder );
             } );
 
             test( 'has aria-describedby according to placeholder text, if defined', () => {
-                const expectedPlaceholder = nyuProps.ui.searchScopeDropdown.options[
-                    nyuProps.ui.searchScopeDropdown.defaultOption
-                ].placeholder;
+                const expectedPlaceholder =
+                    wrapper.vm.option( nyuProps.ui.searchScopeDropdown.defaultOption )
+                        ?.placeholder;
                 expect( input.attributes( 'aria-describedby' ) ).toBe( expectedPlaceholder );
             } );
         } );


### PR DESCRIPTION
* Changed `ui.searchScopeDropdown.options` in NYU and NYUSH config from objects to arrays to ensure reliable ordering of options in the dropdown.  (i.e. Do not rely on `v-for` to always use definition order when iterating through object keys)
* Updated references in Vue component and tests