### PR TITLE
Enable single `vitest` test run for all deployment environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ docker compose up eslint-fix
 ```shell
 npm run test
 ```
+Update `vitest` snapshots:
+
+```shell
+npm run test:update-snapshots
+```
 
 Using Docker Compose:
 
@@ -184,18 +189,6 @@ docker compose up test
 ---
 
 ## Caveats
-
-### Running `vitest --update` one time and commiting the snapshots changes will result in half of the snapshots being mistakenly deleted
-
-See the long file header comment in for _src/test/App.vue/App.vue.spec.js_ for
-details on why this happens and the way to work around this issue.  We will
-likely be able to fix this issue later, but for now, updating the vitest snapshots
-is a two-step manual process.
-
-### For now, do not add an `update-snapshots` npm script to _package.json_
-
-See caveat "Running `vitest --update` one time and commiting the snapshots changes will
-result in half of the snapshots being mistakenly deleted".
 
 ### Do not put `<style>` tags in SFCs
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Using Docker Compose:
 docker compose up test
 ```
 
+Update `vitest` snapshots:
+
+```shell
+docker compose up test-update-snapshots
+```
+
 ---
 
 ## References

--- a/config/index.js
+++ b/config/index.js
@@ -1,3 +1,22 @@
+// This is not necessarily the optimal way to be setting up configuration.
+// Originally BESS was designed to be general purpose reusable component that
+// could potentially be used by non-programmers.  The configuration was done in
+// a single large YAML file to make it easier for non-technical people to
+// change.  We've since decided to maintain and support BESS for certain curated
+// pages/websites only, so we are gradually switching to a more conventional
+// approach to JS application configuration.  This simple config module is the
+// first step.  It DRY'ed up some duplication in the YAML file and allowed us to
+// reconfigure the link URLs based on the deployment environment, which became
+// necessary after migrating to Primo VE, which put all deployment environments
+// on the same domain, with environment differentiation done via the `vid` URL
+// query param.
+//
+// The feature sets of the institutions have started to diverge, and BESS in
+// general is becoming more complex.  It is likely that this module will be
+// obsoleted by a new architecture that does not require centralization of all
+// configuration in one place.  In the meantime, take note of the
+// `makeNewConfig()` factory functions in this and all submodules, which exist
+// solely to make testing easier.
 import shared from './shared.js';
 import NYU from './institutions/nyu.js';
 import NYUAD from './institutions/nyuad.js';

--- a/config/index.js
+++ b/config/index.js
@@ -3,11 +3,19 @@ import NYUAD from './institutions/nyuad.js';
 import NYUSH from './institutions/nyush.js';
 import NYU_HOME from './institutions/nyu-home.js';
 
+// This factory exists solely to allow the `vitest` to test both prod and non-prod
+// builds in the same test run.  See file header for src/test/App.vue/App.vue.spec.js.
+function makeNewConfig() {
+    return {
+        institutions: {
+            NYU       : NYU.makeNewConfig(),
+            NYUAD     : NYUAD.makeNewConfig(),
+            NYUSH     : NYUSH.makeNewConfig(),
+            'NYU_HOME': NYU_HOME.makeNewConfig(),
+        },
+    };
+}
+
 export default {
-    institutions: {
-        NYU,
-        NYUAD,
-        NYUSH,
-        'NYU_HOME': NYU_HOME,
-    },
+    makeNewConfig,
 };

--- a/config/index.js
+++ b/config/index.js
@@ -1,3 +1,4 @@
+import shared from './shared.js';
 import NYU from './institutions/nyu.js';
 import NYUAD from './institutions/nyuad.js';
 import NYUSH from './institutions/nyush.js';
@@ -17,5 +18,6 @@ function makeNewConfig() {
 }
 
 export default {
+    DEPLOY_ENV_PROD: shared.DEPLOY_ENV_PROD,
     makeNewConfig,
 };

--- a/config/institutions/nyu-home.js
+++ b/config/institutions/nyu-home.js
@@ -1,24 +1,34 @@
 import shared from '../shared.js';
 
-const vid = shared.isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
+// See function header comment for `makeNewConfig()` in index.js for the reason
+// we need these factor methods.
+function makeNewConfig() {
+    const sharedConfig = shared.makeNewConfig();
 
-export default [
-    {
-        ...shared.tabs.catalogSearch,
-        open: {
-            'href'  : `https://search.library.nyu.edu/discovery/search?vid=${ vid }`,
-            'target': '_blank',
+    const vid = shared.isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
+
+    return   [
+        {
+            ...sharedConfig.tabs.catalogSearch,
+            open: {
+                'href'  : `https://search.library.nyu.edu/discovery/search?vid=${ vid }`,
+                'target': '_blank',
+            },
+            engine: {
+                ...sharedConfig.engines.nyuPrimoEngine,
+                scope: 'CI_NYU_CONSORTIA',
+            },
+            more: [
+                `<a href="https://search.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
+                `<a href="https://search.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">For full text articles use the search by citation tool</a>`,
+                `<a href="https://search.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank" class="external-link">My Library Account</a>`,
+            ],
         },
-        engine: {
-            ...shared.engines.nyuPrimoEngine,
-            scope: 'CI_NYU_CONSORTIA',
-        },
-        more: [
-            `<a href="https://search.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
-            `<a href="https://search.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">For full text articles use the search by citation tool</a>`,
-            `<a href="https://search.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank" class="external-link">My Library Account</a>`,
-        ],
-    },
-    shared.tabs.guidesArticles,
-    shared.tabs.aresReserves,
-];
+        sharedConfig.tabs.guidesArticles,
+        sharedConfig.tabs.aresReserves,
+    ];
+}
+
+export default {
+    makeNewConfig,
+}

--- a/config/institutions/nyu.js
+++ b/config/institutions/nyu.js
@@ -1,64 +1,74 @@
 import shared from '../shared.js';
 
-const vid = shared.isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
+// See function header comment for `makeNewConfig()` in index.js for the reason
+// we need these factor methods.
+function makeNewConfig() {
+    const sharedConfig = shared.makeNewConfig();
 
-// For details on why we are using empty strings for all `placeholder` values,
-// see https://nyu-lib.monday.com/boards/765008773/pulses/7296310519.
-export default [
-    {
-        ...shared.tabs.catalogSearch,
-        engine: {
-            ...shared.engines.nyuPrimoEngine,
-        },
-        more: [
-            `<a href="https://search.library.nyu.edu/discovery/search?vid=${ vid }&lang=en&mode=advanced" target="_blank">Advanced search</a>`,
-            `Need the full text of an article? <a href="https://search.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-        ui: {
-            // Source: search scopes dropdown in Primo
-            // xpath query as of 2024-08-15: /html/body/primo-explore/div/prm-explore-main/div/prm-search-bar/div[1]/div/div[2]/div/form/div/div/div[2]/prm-tabs-and-scopes-selector/div/md-input-container/md-select/div/md-select-menu/md-content/div[2]
-            searchScopeDropdown: {
-                defaultOption: 'CI_NYU_CONSORTIA',
-                options      : [
-                    {
-                        label      : 'Library catalog',
-                        placeholder: '',
-                        value      : 'CI_NYU_CONSORTIA',
-                    },
-                    {
-                        label      : 'Library catalog (excluding articles)',
-                        placeholder: '',
-                        value      : 'NYU_CONSORTIA',
-                    },
-                    {
-                        label      : 'Articles',
-                        placeholder: '',
-                        value      : 'ARTICLES',
-                    },
-                    {
-                        label      : 'NYU Avery Fisher Center (A/V materials)',
-                        placeholder: '',
-                        value      : 'NYUBAFC',
-                    },
-                    {
-                        value      : 'NYUSC',
-                        label      : 'NYU Special Collections',
-                        placeholder: '',
-                    },
-                ],
+    const vid = shared.isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
+
+    // For details on why we are using empty strings for all `placeholder` values,
+    // see https://nyu-lib.monday.com/boards/765008773/pulses/7296310519.
+    return [
+        {
+            ...sharedConfig.tabs.catalogSearch,
+            engine: {
+                ...sharedConfig.engines.nyuPrimoEngine,
+            },
+            more: [
+                `<a href="https://search.library.nyu.edu/discovery/search?vid=${ vid }&lang=en&mode=advanced" target="_blank">Advanced search</a>`,
+                `Need the full text of an article? <a href="https://search.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+            ui: {
+                // Source: search scopes dropdown in Primo
+                // xpath query as of 2024-08-15: /html/body/primo-explore/div/prm-explore-main/div/prm-search-bar/div[1]/div/div[2]/div/form/div/div/div[2]/prm-tabs-and-scopes-selector/div/md-input-container/md-select/div/md-select-menu/md-content/div[2]
+                searchScopeDropdown: {
+                    defaultOption: 'CI_NYU_CONSORTIA',
+                    options      : [
+                        {
+                            label      : 'Library catalog',
+                            placeholder: '',
+                            value      : 'CI_NYU_CONSORTIA',
+                        },
+                        {
+                            label      : 'Library catalog (excluding articles)',
+                            placeholder: '',
+                            value      : 'NYU_CONSORTIA',
+                        },
+                        {
+                            label      : 'Articles',
+                            placeholder: '',
+                            value      : 'ARTICLES',
+                        },
+                        {
+                            label      : 'NYU Avery Fisher Center (A/V materials)',
+                            placeholder: '',
+                            value      : 'NYUBAFC',
+                        },
+                        {
+                            value      : 'NYUSC',
+                            label      : 'NYU Special Collections',
+                            placeholder: '',
+                        },
+                    ],
+                },
             },
         },
-    },
-    {
-        ...shared.tabs.guidesArticles,
-        label: 'Databases',
-    },
-    {
-        ...shared.tabs.subjectGuides,
-        open: {
-            href  : 'https://guides.nyu.edu',
-            target: '_blank',
+        {
+            ...sharedConfig.tabs.guidesArticles,
+            label: 'Databases',
         },
-    },
-    shared.tabs.aresReserves,
-];
+        {
+            ...sharedConfig.tabs.subjectGuides,
+            open: {
+                href  : 'https://guides.nyu.edu',
+                target: '_blank',
+            },
+        },
+        sharedConfig.tabs.aresReserves,
+    ];
+}
+
+export default {
+    makeNewConfig,
+};

--- a/config/institutions/nyuad.js
+++ b/config/institutions/nyuad.js
@@ -1,67 +1,77 @@
 import shared from '../shared.js';
 
-const vid = shared.isDeployEnvProd() ? '01NYU_AD:AD' : '01NYU_AD:AD_DEV';
+// See function header comment for `makeNewConfig()` in index.js for the reason
+// we need these factor methods.
+function makeNewConfig() {
+    const sharedConfig = shared.makeNewConfig();
 
-const abuDhabiPrimoEngine = {
-    type       : 'primo',
-    institution: 'NYUAD',
-    primoUrl   : 'https://search.abudhabi.library.nyu.edu',
-    vid        : vid,
-    tab        : 'default_slot',
+    const vid = shared.isDeployEnvProd() ? '01NYU_AD:AD' : '01NYU_AD:AD_DEV';
+
+    const abuDhabiPrimoEngine = {
+        type       : 'primo',
+        institution: 'NYUAD',
+        primoUrl   : 'https://search.abudhabi.library.nyu.edu',
+        vid        : vid,
+        tab        : 'default_slot',
+    };
+
+    return [
+        {
+            ...sharedConfig.tabs.catalogSearch,
+            engine: {
+                ...abuDhabiPrimoEngine,
+                scope: 'CI_NYUAD_NYU',
+            },
+            more: [
+                `<a href="https://search.abudhabi.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
+                `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+        },
+        {
+            ...sharedConfig.tabs.guidesArticles,
+            // Override `open`
+            open: {
+                href  : 'http://guides.nyu.edu/adarch',
+                target: '_blank',
+            },
+        },
+        {
+            // We don't want the `open` from `aresReserves`, just `label`
+            // and `title`.
+            label : sharedConfig.tabs.aresReserves.label,
+            title : sharedConfig.tabs.aresReserves.title,
+            engine: {
+                ...abuDhabiPrimoEngine,
+                scope: 'CourseReserves',
+            },
+            more: [
+                `<a href="https://search.abudhabi.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
+                `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+        },
+        {
+            ...sharedConfig.tabs.subjectGuides,
+            engine: {
+                ...sharedConfig.engines.guidesEngine,
+                placeholder: 'Enter Search Words (e.g. Company research)',
+            },
+            more: [
+                '<a href="https://guides.nyu.edu/" target="_blank">All Research Guides</a>',
+                '<a href="https://guides.nyu.edu/abudhabi" target="_blank">Abu Dhabi Library Research Guides</a>',
+                `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+        },
+        {
+            ...sharedConfig.tabs.myAccounts,
+            more: [
+                '<a href="https://ill.library.nyu.edu/" target="_blank">Interlibrary Loan</a>',
+                `<a href="https://search.abudhabi.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank">Library Account</a>`,
+                `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+        },
+    ];
+}
+
+export default {
+    makeNewConfig,
 };
-
-export default [
-    {
-        ...shared.tabs.catalogSearch,
-        engine: {
-            ...abuDhabiPrimoEngine,
-            scope: 'CI_NYUAD_NYU',
-        },
-        more: [
-            `<a href="https://search.abudhabi.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
-            `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-    },
-    {
-        ...shared.tabs.guidesArticles,
-        // Override `open`
-        open: {
-            href  : 'http://guides.nyu.edu/adarch',
-            target: '_blank',
-        },
-    },
-    {
-        // We don't want the `open` from `aresReserves`, just `label`
-        // and `title`.
-        label : shared.tabs.aresReserves.label,
-        title : shared.tabs.aresReserves.title,
-        engine: {
-            ...abuDhabiPrimoEngine,
-            scope: 'CourseReserves',
-        },
-        more: [
-            `<a href="https://search.abudhabi.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
-            `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-    },
-    {
-        ...shared.tabs.subjectGuides,
-        engine: {
-            ...shared.engines.guidesEngine,
-            placeholder: 'Enter Search Words (e.g. Company research)',
-        },
-        more: [
-            '<a href="https://guides.nyu.edu/" target="_blank">All Research Guides</a>',
-            '<a href="https://guides.nyu.edu/abudhabi" target="_blank">Abu Dhabi Library Research Guides</a>',
-            `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-    },
-    {
-        ...shared.tabs.myAccounts,
-        more: [
-            '<a href="https://ill.library.nyu.edu/" target="_blank">Interlibrary Loan</a>',
-            `<a href="https://search.abudhabi.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank">Library Account</a>`,
-            `Need the full text of an article? <a href="https://search.abudhabi.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-    },
-];

--- a/config/institutions/nyush.js
+++ b/config/institutions/nyush.js
@@ -1,86 +1,96 @@
 import shared from '../shared.js';
 
-const vid = shared.isDeployEnvProd() ? '01NYU_US:SH' : '01NYU_US:SH_DEV';
+// See function header comment for `makeNewConfig()` in index.js for the reason
+// we need these factor methods.
+function makeNewConfig() {
+    const sharedConfig = shared.makeNewConfig();
 
-const shanghaiPrimoEngine = {
-    type       : 'primo',
-    institution: 'NYUSH',
-    primoUrl   : 'https://search.shanghai.library.nyu.edu',
-    vid        : vid,
-    scope      : 'CI_NYUSH',
-    tab        : 'default_slot',
-};
+    const vid = shared.isDeployEnvProd() ? '01NYU_US:SH' : '01NYU_US:SH_DEV';
 
-export default [
-    {
-        ...shared.tabs.catalogSearch,
-        engine: { ...shanghaiPrimoEngine },
-        more  : [
-            `<a href="https://search.shanghai.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
-            `Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-        ui: {
-            // Source: search scopes dropdown in Primo
-            // xpath query as of 2024-08-15: /html/body/primo-explore/div/prm-explore-main/div/prm-search-bar/div[1]/div/div[2]/div/form/div/div/div[2]/prm-tabs-and-scopes-selector/div/md-input-container/md-select/div/md-select-menu/md-content/div[2]
-            searchScopeDropdown: {
-                defaultOption: 'CI_NYUSH',
-                options      : [
-                    {
-                        label      : 'All at Shanghai',
-                        placeholder: '',
-                        value      : 'CI_NYUSH',
-                    },
-                    {
-                        label      : 'All at NYU',
-                        placeholder: '',
-                        value      : 'CI_NYUSH_NYU_CONSORTIA',
-                    },
-                    // Do not change this to CI_ARTICLES.  The search scope query
-                    // parameter is apparently case-sensitive.  Compare results:
-                    //
-                    // * "CI_articles": https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&search_scope=CI_articles&vid=01NYU_US:SH&offset=0
-                    // * "CI_ARTICLES": https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&search_scope=CI_ARTICLES&vid=01NYU_US:SH&offset=0
-                    //
-                    // As of 2024-09-16, the CI_ARTICLES URL redirects to:
-                    // https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&vid=01NYU_US:SH&offset=0
-                    // ...`search_scope` query param is removed.
-                    {
-                        label      : 'All Articles',
-                        placeholder: '',
-                        value      : 'CI_articles',
-                    },
-                    {
-                        label      : 'Classic Search',
-                        placeholder: '',
-                        value      : 'NYUSH',
-                    },
-                ],
+    const shanghaiPrimoEngine = {
+        type       : 'primo',
+        institution: 'NYUSH',
+        primoUrl   : 'https://search.shanghai.library.nyu.edu',
+        vid        : vid,
+        scope      : 'CI_NYUSH',
+        tab        : 'default_slot',
+    };
+
+    return [
+        {
+            ...sharedConfig.tabs.catalogSearch,
+            engine: { ...shanghaiPrimoEngine },
+            more  : [
+                `<a href="https://search.shanghai.library.nyu.edu/discovery/search?vid=${ vid }&mode=advanced" target="_blank">Advanced search</a>`,
+                `Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+            ui: {
+                // Source: search scopes dropdown in Primo
+                // xpath query as of 2024-08-15: /html/body/primo-explore/div/prm-explore-main/div/prm-search-bar/div[1]/div/div[2]/div/form/div/div/div[2]/prm-tabs-and-scopes-selector/div/md-input-container/md-select/div/md-select-menu/md-content/div[2]
+                searchScopeDropdown: {
+                    defaultOption: 'CI_NYUSH',
+                    options      : [
+                        {
+                            label      : 'All at Shanghai',
+                            placeholder: '',
+                            value      : 'CI_NYUSH',
+                        },
+                        {
+                            label      : 'All at NYU',
+                            placeholder: '',
+                            value      : 'CI_NYUSH_NYU_CONSORTIA',
+                        },
+                        // Do not change this to CI_ARTICLES.  The search scope query
+                        // parameter is apparently case-sensitive.  Compare results:
+                        //
+                        // * "CI_articles": https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&search_scope=CI_articles&vid=01NYU_US:SH&offset=0
+                        // * "CI_ARTICLES": https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&search_scope=CI_ARTICLES&vid=01NYU_US:SH&offset=0
+                        //
+                        // As of 2024-09-16, the CI_ARTICLES URL redirects to:
+                        // https://search.shanghai.library.nyu.edu/discovery/search?query=any,contains,art&tab=default_slot&vid=01NYU_US:SH&offset=0
+                        // ...`search_scope` query param is removed.
+                        {
+                            label      : 'All Articles',
+                            placeholder: '',
+                            value      : 'CI_articles',
+                        },
+                        {
+                            label      : 'Classic Search',
+                            placeholder: '',
+                            value      : 'NYUSH',
+                        },
+                    ],
+                },
             },
         },
-    },
-    {
-        ...shared.tabs.guidesArticles,
-        label: 'Databases',
-    },
-    shared.tabs.aresReserves,
-    {
-        ...shared.tabs.subjectGuides,
-        engine: {
-            ...shared.engines.guidesEngine,
-            placeholder: 'Enter Search Words (e.g. "learning Chinese")',
+        {
+            ...sharedConfig.tabs.guidesArticles,
+            label: 'Databases',
         },
-        more: [
-            '<a href="https://guides.nyu.edu/" target="_blank">All Research Guides</a>',
-            '<a href="https://guides.nyu.edu/?group_id=5748" target="_blank">Shanghai Library Research Guides</a>',
-            `Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-    },
-    {
-        ...shared.tabs.myAccounts,
-        more: [
-            '<a href="https://ill.library.nyu.edu/" target="_blank">Interlibrary Loan</a>',
-            `<a href="https://search.shanghai.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank">Library Account</a>`,
-            `Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
-        ],
-    },
-];
+        sharedConfig.tabs.aresReserves,
+        {
+            ...sharedConfig.tabs.subjectGuides,
+            engine: {
+                ...sharedConfig.engines.guidesEngine,
+                placeholder: 'Enter Search Words (e.g. "learning Chinese")',
+            },
+            more: [
+                '<a href="https://guides.nyu.edu/" target="_blank">All Research Guides</a>',
+                '<a href="https://guides.nyu.edu/?group_id=5748" target="_blank">Shanghai Library Research Guides</a>',
+                `Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+        },
+        {
+            ...sharedConfig.tabs.myAccounts,
+            more: [
+                '<a href="https://ill.library.nyu.edu/" target="_blank">Interlibrary Loan</a>',
+                `<a href="https://search.shanghai.library.nyu.edu/discovery/account?vid=${ vid }&section=overview" target="_blank">Library Account</a>`,
+                `Need the full text of an article? <a href="https://search.shanghai.library.nyu.edu/discovery/citationlinker?vid=${ vid }" target="_blank">Use the search by citation tool</a>.`,
+            ],
+        },
+    ];
+}
+
+export default {
+    makeNewConfig,
+}

--- a/config/shared.js
+++ b/config/shared.js
@@ -58,6 +58,7 @@ function makeNewConfig() {
 }
 
 export default {
+    DEPLOY_ENV_PROD,
     isDeployEnvProd,
     makeNewConfig,
 }

--- a/config/shared.js
+++ b/config/shared.js
@@ -1,54 +1,63 @@
 const DEPLOY_ENV_PROD = 'prod';
 
-const vid = isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
-
 function isDeployEnvProd() {
     return import.meta.env.VITE_DEPLOY_ENV?.toLowerCase().trim() === DEPLOY_ENV_PROD;
 }
 
+// See function header comment for `makeNewConfig()` in index.js for the reason
+// we need these factor methods.
+function makeNewConfig() {
+    const vid = isDeployEnvProd() ? '01NYU_INST:NYU' : '01NYU_INST:NYU_DEV';
+
+    return {
+        isDeployEnvProd,
+        tabs: {
+            aresReserves: {
+                label: 'Course Reserves',
+                title: 'Search for library materials that are held at one location for a particular course',
+                open : {
+                    href  : 'https://ares.library.nyu.edu/',
+                    target: '_blank',
+                },
+            },
+            catalogSearch: {
+                label: 'Catalog Search',
+                title: 'Search NYU\'s catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings',
+            },
+            guidesArticles: {
+                label: 'Articles & Databases',
+                title: 'Search databases for articles or browse databases by subject',
+                open : {
+                    href  : 'http://guides.nyu.edu/arch',
+                    target: '_blank',
+                },
+            },
+            subjectGuides: {
+                label: 'Research Guides',
+                title: 'Guides to help you find library resources on specific subjects and courses',
+            },
+            myAccounts: {
+                label: 'My Accounts',
+                title: 'My Accounts',
+            },
+        },
+        engines: {
+            guidesEngine: {
+                type     : 'guides',
+                guidesUrl: 'https://guides.nyu.edu',
+            },
+            nyuPrimoEngine: {
+                type       : 'primo',
+                institution: 'NYU',
+                primoUrl   : 'https://search.library.nyu.edu',
+                vid        : vid,
+                tab        : 'Unified_Slot',
+            },
+        },
+    };
+}
+
 export default {
     isDeployEnvProd,
-    tabs: {
-        aresReserves: {
-            label: 'Course Reserves',
-            title: 'Search for library materials that are held at one location for a particular course',
-            open : {
-                href  : 'https://ares.library.nyu.edu/',
-                target: '_blank',
-            },
-        },
-        catalogSearch: {
-            label: 'Catalog Search',
-            title: 'Search NYU\'s catalog for books, journals, scripts, scores, archival materials, NYU dissertations, videos, sound recordings',
-        },
-        guidesArticles: {
-            label: 'Articles & Databases',
-            title: 'Search databases for articles or browse databases by subject',
-            open : {
-                href  : 'http://guides.nyu.edu/arch',
-                target: '_blank',
-            },
-        },
-        subjectGuides: {
-            label: 'Research Guides',
-            title: 'Guides to help you find library resources on specific subjects and courses',
-        },
-        myAccounts: {
-            label: 'My Accounts',
-            title: 'My Accounts',
-        },
-    },
-    engines: {
-        guidesEngine: {
-            type     : 'guides',
-            guidesUrl: 'https://guides.nyu.edu',
-        },
-        nyuPrimoEngine: {
-            type       : 'primo',
-            institution: 'NYU',
-            primoUrl   : 'https://search.library.nyu.edu',
-            vid        : vid,
-            tab        : 'Unified_Slot',
-        },
-    },
-};
+    makeNewConfig,
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,3 +74,7 @@ services:
     <<: *x-build
 #    <<: [ *x-build, *default-volumes ]
     command: npm run test
+
+  test-update-snapshots:
+    <<: [ *x-build, *default-volumes ]
+    command: npm run test:update-snapshots

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "build:prod": "NODE_ENV=production VITE_DEPLOY_ENV=prod npm run build -- --mode=production",
     "build:prod:watch": "npm run build:prod -- --watch",
     "preview": "vite preview",
-    "test": "npm run test:unit && npm run test:unit:app:prod",
-    "test:unit": "NODE_ENV=production vitest run",
-    "test:unit:app:prod": "NODE_ENV=production VITE_DEPLOY_ENV=prod vitest run --mode=production src/test/App.vue/App.vue.spec.js",
+    "test": "NODE_ENV=production vitest run",
+    "test:update-snapshots": "NODE_ENV=production vitest run --update",
     "update-browser-overrides": "npm run build:prod && scripts/update-browser-overrides-app-builds.sh",
     "eslint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --ignore-path .gitignore",
     "eslint:fix": "npm run eslint -- --fix"

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 import { createApp } from 'vue';
 import App from './App.vue';
-import config from '../config/index.js';
+import bessConfig from '../config/index.js';
+
+const config = bessConfig.makeNewConfig();
 
 // source: http://2ality.com/2014/05/current-script.html
 const currentScript = document.currentScript || ( function() {

--- a/src/test/App.vue/App.vue.spec.js
+++ b/src/test/App.vue/App.vue.spec.js
@@ -71,7 +71,7 @@ import bessConfig from '../../../config/';
 
 const envTestCases = [
     {
-        envValue: 'prod',
+        envValue: bessConfig.DEPLOY_ENV_PROD,
     },
     {
         envValue: undefined,

--- a/src/test/App.vue/App.vue.spec.js
+++ b/src/test/App.vue/App.vue.spec.js
@@ -69,123 +69,152 @@ import { config, mount } from '@vue/test-utils';
 import App from '@/App.vue';
 import bessConfig from '../../../config/';
 
-const appConfig = bessConfig.makeNewConfig();
+const envTestCases = [
+    {
+        envValue: 'prod',
+    },
+    {
+        envValue: undefined,
+    },
+];
 
-describe( `App [ VITE_DEPLOY_ENV: ${ process.env.VITE_DEPLOY_ENV } ]`, () => {
-    let wrapper;
+describe.each( envTestCases )(
+    'App builds correctly for VITE_DEPLOY_ENV=$envValue', ( { envValue } ) => {
+        vi.stubEnv( 'VITE_DEPLOY_ENV', envValue );
+        const appConfig = bessConfig.makeNewConfig();
 
-    describe.each(
-        Object.keys( appConfig.institutions ).map(
-            function ( institution ) {
-                return { institution };
-            },
-        ) )( '$institution', ( { institution } ) => {
-        beforeEach( () => {
-            config.global.mocks = {
-                $config: appConfig.institutions[ institution ],
-            };
+        let wrapper;
 
-            wrapper = mount( App );
-        } );
-
-        test( 'has the correct HTML', () => {
-            expect( wrapper.html() ).toMatchSnapshot();
-        } );
-
-        // This test suite assumes that the default tab is the engine search tab.
-        describe( 'engine search should call `window.open` with correct URL', () => {
-            // A single TAB followed by three spaces
-            const ALL_WHITESPACE_SEARCH = '    ';
-            const EMPTY_SEARCH = '';
-            const NON_EMPTY_SEARCH = 'art';
-
-            const testState = {
-                target: undefined,
-                reset() {
-                    this.target = undefined;
+        describe.each(
+            Object.keys( appConfig.institutions ).map(
+                function ( institution ) {
+                    return { institution };
                 },
-            };
-
-            // This is used for the `describe.runIf` test conditions below.
-            // Originally tried to do something like this:
-            //
-            //    describe.runIf( appConfig.institutions[ institution ][ 0 ].ui?.searchScopeDropdown )( ...
-            //        describe.each( [...appConfig.institutions[ institution ][ 0 ].ui.searchScopeDropdown.options.map( option => { searchScopeDropdownValue: option } )( ...
-            //
-            // ...but it looks like the `describe.each` test is evaluated whether
-            // the `describe.runIf` condition is truthy or not, leading to errors
-            // when trying to read the `searchScopeDropdown` property of an
-            // undefined `appConfig.institutions[ institution ][ 0 ].ui`.
-            let currentConfig = appConfig.institutions[ institution ];
-            let searchScopeDropdownOptionValues = currentConfig[ 0 ].ui?.searchScopeDropdown.options ?
-                currentConfig[ 0 ].ui?.searchScopeDropdown.options :
-                [];
-
+            ) )( '$institution', ( { institution } ) => {
             beforeEach( () => {
-                // Suppress error "Error: Not implemented: window.open", which doesn't
-                // cause the test to fail but does make test output harder to read.
-                vi.stubGlobal( 'open', vi.fn( ( location ) => {
-                    testState.called = true;
-                    testState.target = location;
-                } ) );
-
                 config.global.mocks = {
                     $config: appConfig.institutions[ institution ],
                 };
 
                 wrapper = mount( App );
-
-                testState.reset();
             } );
 
-            // Test URLs
-            describe.runIf( searchScopeDropdownOptionValues.length > 0 )( 'with user-selected search scope', () => {
-                describe.each(
-                    [
-                        ...searchScopeDropdownOptionValues.map( function ( option ) {
-                            return { 'searchScopeDropdownValue': option.value }
-                        } ),
-                    ],
-                )(
-                    '$searchScopeDropdownValue', ( { searchScopeDropdownValue } ) => {
-                        test.each(
-                            [
-                                { title: 'empty search', inputValue: EMPTY_SEARCH },
-                                { title: 'all-whitespace search', inputValue: ALL_WHITESPACE_SEARCH },
-                                { title: 'non-empty search', inputValue: NON_EMPTY_SEARCH },
-                            ] )( '$title: $inputValue', async ( { inputValue } ) => {
-                            expect( testState.target ).toBeUndefined();
+            test( 'has the correct HTML', () => {
+                expect( wrapper.html() ).toMatchSnapshot();
+            } );
 
-                            const form = wrapper.find( 'form' )
-                            const searchScopeDropdown = form.find( 'select' );
-                            const input = form.find( 'input' );
-                            await searchScopeDropdown.setValue( searchScopeDropdownValue );
-                            await input.setValue( inputValue );
-                            form.trigger( 'submit' );
+            // This test suite assumes that the default tab is the engine search tab.
+            describe( 'engine search should call `window.open` with correct URL', () => {
+                // A single TAB followed by three spaces
+                const ALL_WHITESPACE_SEARCH = '    ';
+                const EMPTY_SEARCH = '';
+                const NON_EMPTY_SEARCH = 'art';
 
-                            expect( testState.target ).toMatchSnapshot();
-                        } )
+                const testState = {
+                    target: undefined,
+                    reset() {
+                        this.target = undefined;
                     },
-                );
-            } );
+                };
 
-            describe.runIf( searchScopeDropdownOptionValues.length === 0 )( `with hardcoded scope: ${ currentConfig[ 0 ].engine.scope }`, () => {
-                test.each(
-                    [
-                        { title: 'empty search', inputValue: EMPTY_SEARCH },
-                        { title: 'all-whitespace search', inputValue: ALL_WHITESPACE_SEARCH },
-                        { title: 'non-empty search', inputValue: NON_EMPTY_SEARCH },
-                    ] )( '$title: $inputValue', async ( { inputValue } ) => {
-                    expect( testState.target ).toBeUndefined();
+                // This is used for the `describe.runIf` test conditions below.
+                // Originally tried to do something like this:
+                //
+                //    describe.runIf( appConfig.institutions[ institution ][ 0 ].ui?.searchScopeDropdown )( ...
+                //        describe.each( [...appConfig.institutions[ institution ][ 0 ].ui.searchScopeDropdown.options.map( option => { searchScopeDropdownValue: option } )( ...
+                //
+                // ...but it looks like the `describe.each` test is evaluated whether
+                // the `describe.runIf` condition is truthy or not, leading to errors
+                // when trying to read the `searchScopeDropdown` property of an
+                // undefined `appConfig.institutions[ institution ][ 0 ].ui`.
+                let currentConfig = appConfig.institutions[ institution ];
+                let searchScopeDropdownOptionValues = currentConfig[ 0 ].ui?.searchScopeDropdown.options ?
+                    currentConfig[ 0 ].ui?.searchScopeDropdown.options :
+                    [];
 
-                    const form = wrapper.find( 'form' )
-                    const input = form.find( 'input' );
-                    await input.setValue( inputValue );
-                    form.trigger( 'submit' );
+                beforeEach( () => {
+                    // Suppress error "Error: Not implemented: window.open", which doesn't
+                    // cause the test to fail but does make test output harder to read.
+                    vi.stubGlobal( 'open', vi.fn( ( location ) => {
+                        testState.called = true;
+                        testState.target = location;
+                    } ) );
 
-                    expect( testState.target ).toMatchSnapshot();
-                } )
-            } );
-        } );
+                    config.global.mocks = {
+                        $config: appConfig.institutions[ institution ],
+                    };
+
+                    wrapper = mount( App );
+
+                    testState.reset();
+                } );
+
+                // Test URLs
+                describe.runIf( searchScopeDropdownOptionValues.length > 0 )( 'with user-selected search scope', () => {
+                    describe.each(
+                        [
+                            ...searchScopeDropdownOptionValues.map( function ( option ) {
+                                return { 'searchScopeDropdownValue': option.value }
+                            } ),
+                        ],
+                    )(
+                        '$searchScopeDropdownValue', ( { searchScopeDropdownValue } ) => {
+                            test.each(
+                                [
+                                    {
+                                        title     : 'empty search',
+                                        inputValue: EMPTY_SEARCH,
+                                    },
+                                    {
+                                        title     : 'all-whitespace search',
+                                        inputValue: ALL_WHITESPACE_SEARCH,
+                                    },
+                                    {
+                                        title     : 'non-empty search',
+                                        inputValue: NON_EMPTY_SEARCH,
+                                    },
+                                ] )( '$title: $inputValue', async ( { inputValue } ) => {
+                                expect( testState.target ).toBeUndefined();
+
+                                const form = wrapper.find( 'form' )
+                                const searchScopeDropdown = form.find( 'select' );
+                                const input = form.find( 'input' );
+                                await searchScopeDropdown.setValue( searchScopeDropdownValue );
+                                await input.setValue( inputValue );
+                                form.trigger( 'submit' );
+
+                                expect( testState.target ).toMatchSnapshot();
+                            } )
+                        },
+                    );
+                } );
+
+                describe.runIf( searchScopeDropdownOptionValues.length === 0 )( `with hardcoded scope: ${ currentConfig[ 0 ].engine.scope }`, () => {
+                    test.each(
+                        [
+                            {
+                                title     : 'empty search',
+                                inputValue: EMPTY_SEARCH,
+                            },
+                            {
+                                title     : 'all-whitespace search',
+                                inputValue: ALL_WHITESPACE_SEARCH,
+                            },
+                            {
+                                title     : 'non-empty search',
+                                inputValue: NON_EMPTY_SEARCH,
+                            },
+                        ] )( '$title: $inputValue', async ( { inputValue } ) => {
+                        expect( testState.target ).toBeUndefined();
+
+                        const form = wrapper.find( 'form' )
+                        const input = form.find( 'input' );
+                        await input.setValue( inputValue );
+                        form.trigger( 'submit' );
+
+                        expect( testState.target ).toMatchSnapshot();
+                    } )
+                } );
+            } )
+        } )
     } );
-} );

--- a/src/test/App.vue/App.vue.spec.js
+++ b/src/test/App.vue/App.vue.spec.js
@@ -67,7 +67,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { config, mount } from '@vue/test-utils';
 import App from '@/App.vue';
-import appConfig from '../../../config/';
+import bessConfig from '../../../config/';
+
+const appConfig = bessConfig.makeNewConfig();
 
 describe( `App [ VITE_DEPLOY_ENV: ${ process.env.VITE_DEPLOY_ENV } ]`, () => {
     let wrapper;

--- a/src/test/App.vue/__snapshots__/App.vue.spec.js.snap
+++ b/src/test/App.vue/__snapshots__/App.vue.spec.js.snap
@@ -1,36 +1,36 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=ARTICLES"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=ARTICLES"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=ARTICLES"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=ARTICLES"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=ARTICLES&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=ARTICLES&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYU_CONSORTIA&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYU_CONSORTIA&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUBAFC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUBAFC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUBAFC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUBAFC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYUBAFC&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYUBAFC&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUSC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUSC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUSC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=NYUSC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYUSC&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=NYUSC&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -64,13 +64,13 @@ exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU' > has the correct HTML 1`] = `
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYU_HOME' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -100,13 +100,13 @@ exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYU_HOME' > has the correct HTML 1`] =
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'all-whitespace search': '    ' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&search_scope=CI_NYUAD_NYU"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'all-whitespace search': '    ' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&search_scope=CI_NYUAD_NYU"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'empty search': '' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&search_scope=CI_NYUAD_NYU"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'empty search': '' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&search_scope=CI_NYUAD_NYU"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'non-empty search': 'art' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?institution=NYUAD&vid=01NYU_AD:AD&tab=default_slot&search_scope=CI_NYUAD_NYU&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'non-empty search': 'art' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?institution=NYUAD&vid=01NYU_AD:AD&tab=default_slot&search_scope=CI_NYUAD_NYU&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUAD' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -137,31 +137,31 @@ exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUAD' > has the correct HTML 1`] = `
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_NYUSH_NYU_CONSORTIA&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_NYUSH_NYU_CONSORTIA&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_articles"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_articles"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_articles"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=CI_articles"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_articles&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=CI_articles&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH&search_scope=NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH&tab=default_slot&search_scope=NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV='prod' > 'NYUSH' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -195,37 +195,37 @@ exports[`App [ VITE_DEPLOY_ENV: prod ] > 'NYUSH' > has the correct HTML 1`] = `
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=ARTICLES"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=ARTICLES"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=ARTICLES"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=ARTICLES"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=ARTICLES&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'ARTICLES' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=ARTICLES&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=NYU_CONSORTIA&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=NYU_CONSORTIA&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUBAFC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUBAFC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUBAFC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUBAFC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=NYUBAFC&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUBAFC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=NYUBAFC&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUSC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUSC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUSC"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=NYUSC"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=NYUSC&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSC' > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=NYUSC&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -259,13 +259,13 @@ exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU' > has the correct HTML 1`] =
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'all-whitespace search': '    ' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'empty search': '' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&search_scope=CI_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU_HOME' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYU_CONSORTIA > 'non-empty search': 'art' 1`] = `"https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&tab=Unified_Slot&search_scope=CI_NYU_CONSORTIA&query=any,contains,art"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU_HOME' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYU_HOME' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -295,13 +295,13 @@ exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYU_HOME' > has the correct HTML 
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'all-whitespace search': '    ' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD_DEV&search_scope=CI_NYUAD_NYU"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'all-whitespace search': '    ' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD_DEV&search_scope=CI_NYUAD_NYU"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'empty search': '' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD_DEV&search_scope=CI_NYUAD_NYU"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'empty search': '' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD_DEV&search_scope=CI_NYUAD_NYU"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'non-empty search': 'art' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?institution=NYUAD&vid=01NYU_AD:AD_DEV&tab=default_slot&search_scope=CI_NYUAD_NYU&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUAD' > engine search should call \`window.open\` with correct URL > with hardcoded scope: CI_NYUAD_NYU > 'non-empty search': 'art' 1`] = `"https://search.abudhabi.library.nyu.edu/discovery/search?institution=NYUAD&vid=01NYU_AD:AD_DEV&tab=default_slot&search_scope=CI_NYUAD_NYU&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUAD' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUAD' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">
@@ -332,31 +332,31 @@ exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUAD' > has the correct HTML 1`]
 </div>"
 `;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=CI_NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=CI_NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_NYUSH_NYU_CONSORTIA"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=CI_NYUSH_NYU_CONSORTIA&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_NYUSH_NYU_CONSORTIA' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=CI_NYUSH_NYU_CONSORTIA&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_articles"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_articles"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_articles"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=CI_articles"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=CI_articles&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'CI_articles' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=CI_articles&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'all-whitespace search': '    ' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=NYUSH"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'empty search': '' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:SH_DEV&search_scope=NYUSH"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > engine search should call \`window.open\` with correct URL > with user-selected search scope > 'NYUSH' > 'non-empty search': 'art' 1`] = `"https://search.shanghai.library.nyu.edu/discovery/search?institution=NYUSH&vid=01NYU_US:SH_DEV&tab=default_slot&search_scope=NYUSH&mode=basic&displayMode=full&bulkSize=10&dum=true&displayField=all&primoQueryTemp=art&query=any,contains,art&sortby=rank&lang=en"`;
 
-exports[`App [ VITE_DEPLOY_ENV: undefined ] > 'NYUSH' > has the correct HTML 1`] = `
+exports[`App builds correctly for VITE_DEPLOY_ENV=undefined > 'NYUSH' > has the correct HTML 1`] = `
 "<div class="bobcat_embed">
   <div class="bobcat_embed_tabs_wrapper">
     <div class="bobcat_embed_tabs">

--- a/src/test/App.vue/computed.spec.js
+++ b/src/test/App.vue/computed.spec.js
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import { config, shallowMount } from '@vue/test-utils';
 import App from '@/App.vue';
-import appConfig from '../../../config';
+import bessConfig from '../../../config';
+
+const appConfig = bessConfig.makeNewConfig();
 
 describe( 'computed', () => {
     let currentAppConfig;

--- a/src/test/App.vue/data.spec.js
+++ b/src/test/App.vue/data.spec.js
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import { config, shallowMount } from '@vue/test-utils';
 import App from '@/App.vue';
-import appConfig from '../../../config';
+import bessConfig from '../../../config';
+
+const appConfig = bessConfig.makeNewConfig();
 
 describe( 'data', () => {
     let currentAppConfig;

--- a/src/test/App.vue/methods.spec.js
+++ b/src/test/App.vue/methods.spec.js
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import { config, shallowMount } from '@vue/test-utils';
 import App from '@/App.vue';
-import appConfig from '../../../config';
+import bessConfig from '../../../config';
+
+const appConfig = bessConfig.makeNewConfig();
 
 describe( 'methods', () => {
     let currentAppConfig;

--- a/src/test/components/SearchForm.vue.spec.js
+++ b/src/test/components/SearchForm.vue.spec.js
@@ -15,7 +15,9 @@ import { guidesSearch, primoSearch } from '@/utils/searchRedirects.js';
 import SearchForm from '@/components/SearchForm.vue';
 import { shallowMount } from '@vue/test-utils';
 
-import appConfig from '../../../config';
+import bessConfig from '../../../config';
+
+const appConfig = bessConfig.makeNewConfig();
 
 describe( 'SearchForm', () => {
     let currentFormConfig;

--- a/src/test/components/TabItem.vue.spec.js
+++ b/src/test/components/TabItem.vue.spec.js
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 
-import appConfig from '../../../config';
+import bessConfig from '../../../config';
 import TabItem from '@/components/TabItem.vue';
+
+const appConfig = bessConfig.makeNewConfig();
 
 const updateTabSpy = vi.fn( () => 0 );
 

--- a/src/test/components/searchForms/SearchRedirectForm.vue.spec.js
+++ b/src/test/components/searchForms/SearchRedirectForm.vue.spec.js
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 
-import appConfig from '../../../../config';
+import bessConfig from '../../../../config';
 import SearchRedirectForm from '@/components/searchForms/SearchRedirectForm.vue';
+
+const appConfig = bessConfig.makeNewConfig();
 
 const inputAriaLabel = 'Search in library guides';
 const searchFunctionSpy = vi.fn( () => 0 );

--- a/src/test/utils/searchRedirects.spec.js
+++ b/src/test/utils/searchRedirects.spec.js
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import { primoSearch, guidesSearch } from '@/utils/searchRedirects.js';
 
-import appConfig from '../../../config';
+import bessConfig from '../../../config';
+
+const appConfig = bessConfig.makeNewConfig();
 
 // A single TAB followed by three spaces
 const ALL_WHITESPACE_SEARCH = '    ';


### PR DESCRIPTION
Create new `makeNewConfig()` factory methods in the `config` module which allow `vitest` to programmatically switch from prod to non-prod configuration during a test run.  This eliminates warnings of "obsolete" snapshots during test runs and deletions of same when `update` flag is set.